### PR TITLE
feat!: Add `pipe` mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ const credentials = {
 const migration = new Migration({ credentials });
 
 let result = await migration.run();
-if (result !== MigrationState.RequestedPlcOperation) {
+if (result !== 'RequestedPlcOperation') {
   // Something has gone extremely wrong if this happens
   throw new Error('unexpected migration state');
 }
@@ -119,7 +119,7 @@ const confirmationToken = '...';
 migration.confirmationToken = confirmationToken;
 
 result = await migration.run();
-if (result !== MigrationState.Finalized) {
+if (result !== 'Finalized') {
   // Again, something has gone extremely wrong if this happens
   throw new Error('unexpected migration state');
 }
@@ -127,6 +127,25 @@ if (result !== MigrationState.Finalized) {
 // This is the recovery private key for the account, which must be stored
 // somewhere or risk the loss of the account
 storeSomewhereSafe(migration.newPrivateKey);
+```
+
+If you need to persist an unfinished migration, e.g. on failure or when getting
+the confirmation token, you can use the `serialize()`/`deserialize()` methods:
+
+```ts
+const migration = new Migration({ credentials });
+await migration.run();
+
+// NOTE: This will output the user's passwords and private key in plaintext,
+// if present.
+const serialized = migration.serialize();
+saveMigration(JSON.stringify(serialized, null, 2));
+
+// Later
+const savedMigration = loadMigration();
+const migration = Migration.deserialize(JSON.parse(savedMigration));
+migration.confirmationToken = confirmationToken;
+await migration.run();
 ```
 
 ### Troubleshooting

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,8 @@ const config = createConfig([
     },
 
     rules: {
+      'prefer-template': 'off',
+
       'import-x/no-useless-path-segments': 'off',
 
       'jsdoc/require-description': 'off',
@@ -61,6 +63,7 @@ const config = createConfig([
         },
       ],
       '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/prefer-reduce-type-parameter': 'off',
       '@typescript-eslint/unbound-method': 'off',
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ const config = createConfig([
     },
 
     rules: {
+      'no-void': 'off',
       'prefer-template': 'off',
 
       'import-x/no-useless-path-segments': 'off',

--- a/package.json
+++ b/package.json
@@ -44,16 +44,16 @@
   "scripts": {
     "build": "pnpm build:ts-bridge && pnpm build:chmod",
     "build:test": "pnpm build && pnpm build:test:fakes",
-    "build:test:fakes": "esbuild ./test/FakeMigration.ts --bundle --outfile=./dist/migration/Migration.mjs --format=esm --target=es2022 --platform=node --packages=external",
+    "build:test:fakes": "esbuild ./test/FakeMigration.ts --outfile=./dist/migration/Migration.mjs --bundle --format=esm --target=es2022 --platform=node --packages=external",
     "build:ts-bridge": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
     "build:chmod": "chmod +x ./dist/main.mjs && chmod +x ./dist/main.cjs",
-    "lint": "pnpm lint:eslint && pnpm lint:misc --check && pnpm lint:changelog && pnpm lint:dependencies --check && pnpm lint:types",
+    "lint": "pnpm lint:eslint && pnpm lint:misc --check && pnpm lint:types && pnpm lint:changelog && pnpm lint:dependencies --check",
     "lint:changelog": "auto-changelog validate --prettier --repo https://github.com/rekmarks/bluesky-account-migrator.git",
     "lint:dependencies": "depcheck && pnpm dedupe",
     "lint:eslint": "eslint . --cache",
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' '!CHANGELOG.md' '!pnpm-lock.yaml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "lint:types": "tsc --noEmit",
-    "lint:fix": "pnpm lint:eslint --fix && pnpm lint:misc --write && pnpm lint:changelog && pnpm lint:dependencies && pnpm lint:types",
+    "lint:fix": "pnpm lint:eslint --fix && pnpm lint:misc --write && pnpm lint:types && pnpm lint:changelog && pnpm lint:dependencies",
     "test": "vitest run"
   },
   "dependencies": {
@@ -92,7 +92,8 @@
     "eslint-plugin-vitest": "^0.5.4",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "zod": "^3.24.1"
   },
   "engines": {
     "node": "^18.20 || ^20.18 || >=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(@types/node@22.10.2)
+      zod:
+        specifier: ^3.24.1
+        version: 3.24.1
 
 packages:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,17 +4,18 @@ import { hideBin } from 'yargs/helpers';
 import type { Commands } from './commands/index.js';
 import packageJson from 'bluesky-account-migrator/package.json' assert { type: 'json' };
 
+// TODO:next add debug option, make error stack traces hidden by default
 export async function cli(argv: string[], commands: Commands) {
   await yargs(hideBin(argv))
     .scriptName('bluesky-account-migrator')
-    .version(packageJson.version)
-    .usage('Usage: $0 <command> [options]')
     .strict()
-    .demandCommand(1)
-    .command(commands)
+    .usage('Usage: $0 <command> [options]')
+    .version(packageJson.version)
     .help()
     .showHelpOnFail(false)
     .alias('help', 'h')
     .alias('version', 'v')
+    .command(commands)
+    .demandCommand(1)
     .parseAsync();
 }

--- a/src/commands/migrate/handler.test.ts
+++ b/src/commands/migrate/handler.test.ts
@@ -4,8 +4,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { handleMigrateInteractive } from './handler.js';
 import { input } from './prompts.js';
 import { makeMockCredentials } from '../../../test/utils.js';
-import type { MigrationCredentials } from '../../migration/index.js';
-import { Migration, MigrationState } from '../../migration/index.js';
+import type {
+  MigrationCredentials,
+  MigrationState,
+} from '../../migration/index.js';
+import { Migration } from '../../migration/index.js';
 
 vi.mock('../../utils/index.js', async (importOriginal) => ({
   ...(await importOriginal()),
@@ -57,7 +60,7 @@ describe('handleMigrateInteractive', () => {
       this.credentials = arg.credentials;
       this.newPrivateKey = mockPrivateKey;
       this.run = runMock;
-      this.state = MigrationState.Ready;
+      this.state = 'Ready';
       return this as unknown as Migration;
     });
     /* eslint-enable no-invalid-this */
@@ -69,8 +72,8 @@ describe('handleMigrateInteractive', () => {
 
     mockPrivateKey = '0xdeadbeef';
     runMock
-      .mockResolvedValueOnce(MigrationState.RequestedPlcOperation)
-      .mockResolvedValueOnce(MigrationState.Finalized);
+      .mockResolvedValueOnce('RequestedPlcOperation')
+      .mockResolvedValueOnce('Finalized');
 
     await handleMigrateInteractive();
 
@@ -110,7 +113,7 @@ describe('handleMigrateInteractive', () => {
   it('should handle a failed migration in the CreatedNewAccount state', async () => {
     runMock.mockImplementation(async function (this: MockMigration) {
       // eslint-disable-next-line no-invalid-this
-      this.state = MigrationState.CreatedNewAccount;
+      this.state = 'CreatedNewAccount';
       return Promise.reject(new Error('foo'));
     });
 
@@ -133,7 +136,7 @@ describe('handleMigrateInteractive', () => {
     mockPrivateKey = '0xdeadbeef';
     runMock.mockImplementation(async function (this: MockMigration) {
       // eslint-disable-next-line no-invalid-this
-      this.state = MigrationState.MigratedIdentity;
+      this.state = 'MigratedIdentity';
       return Promise.reject(new Error('foo'));
     });
 

--- a/src/commands/migrate/handler.ts
+++ b/src/commands/migrate/handler.ts
@@ -1,6 +1,6 @@
 import { getCredentialsInteractive, validateString } from './credentials.js';
 import { input, pressEnter } from './prompts.js';
-import { Migration, MigrationState } from '../../migration/index.js';
+import { Migration } from '../../migration/index.js';
 import type { MigrationCredentials } from '../../migration/index.js';
 import {
   logError,
@@ -95,7 +95,7 @@ async function executeMigration(
  */
 async function beginMigration(migration: Migration): Promise<void> {
   const result = await migration.run();
-  if (result !== MigrationState.RequestedPlcOperation) {
+  if (result !== 'RequestedPlcOperation') {
     throw new Error(
       `Fatal: Unexpected migration state "${result}" after initial run. Please report this bug.`,
     );
@@ -136,7 +136,7 @@ async function promptForConfirmationToken(
  */
 async function finalizeMigration(migration: Migration): Promise<string> {
   const result = await migration.run();
-  if (result !== MigrationState.Finalized) {
+  if (result !== 'Finalized') {
     throw new Error(
       `Fatal: Unexpected migration state "${result}" after resuming migration. Please report this bug.`,
     );
@@ -166,7 +166,7 @@ function handleSuccess(privateKey: string): void {
 async function handleFailure(migration: Migration): Promise<void> {
   console.log();
   logError(`Error: Migration failed during state "${migration.state}"`);
-  if (migration.state !== MigrationState.Ready) {
+  if (migration.state !== 'Ready') {
     console.log();
     logError(
       'The migration has created a new account, but it may not be ready to use yet.',

--- a/src/commands/migrate/index.ts
+++ b/src/commands/migrate/index.ts
@@ -19,6 +19,7 @@ export const migrateCommand: CommandModule<MigrateOptions> = {
       describe: 'Run in interactive mode',
       type: 'string',
       default: 'interactive',
+      // TODO: ['args', 'a', 'file', 'f', 'interactive', 'i']
       choices: ['interactive', 'i'],
     }) as Argv<{ mode: Mode }>;
   },

--- a/src/commands/migrate/index.ts
+++ b/src/commands/migrate/index.ts
@@ -1,8 +1,9 @@
 import type { Argv, CommandModule as RawCommandModule } from 'yargs';
 
-import { handleMigrateInteractive } from './handler.js';
+import { handleInteractive } from './interactive.js';
+import { handlePipe } from './pipe.js';
 
-type Mode = 'interactive' | 'i';
+type Mode = 'interactive' | 'i' | 'stdin' | 's';
 
 export type MigrateOptions = {
   mode: Mode;
@@ -15,19 +16,25 @@ export const migrateCommand: CommandModule<MigrateOptions> = {
   aliases: ['m'],
   describe: 'Perform a migration',
   builder: (yarg: Argv) => {
-    return yarg.positional('mode', {
-      describe: 'Run in interactive mode',
-      type: 'string',
-      default: 'interactive',
-      // TODO: ['args', 'a', 'file', 'f', 'interactive', 'i']
-      choices: ['interactive', 'i'],
-    }) as Argv<{ mode: Mode }>;
+    return yarg
+      .option('mode', {
+        describe: 'The migration mode to use',
+        type: 'string',
+        default: 'interactive',
+        choices: ['interactive', 'i', 'pipe', 'p'],
+      })
+      .demandOption('mode') as Argv<MigrateOptions>;
   },
   handler: async (argv) => {
     if (argv.mode.startsWith('i')) {
-      await handleMigrateInteractive();
+      await handleInteractive();
+    } else if (argv.mode.startsWith('p')) {
+      await handlePipe();
     } else {
-      throw new Error('Not yet implemented');
+      // This should never happen
+      throw new Error(
+        `Fatal: Migration mode not yet implemented: ${argv.mode}`,
+      );
     }
   },
 };

--- a/src/commands/migrate/interactive.test.ts
+++ b/src/commands/migrate/interactive.test.ts
@@ -1,9 +1,10 @@
 import type { Mock, MockInstance } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { handleMigrateInteractive } from './handler.js';
+import { handleInteractive } from './interactive.js';
 import { input } from './prompts.js';
 import { makeMockCredentials } from '../../../test/utils.js';
+import type { MockMigration } from '../../../test/utils.js';
 import type {
   MigrationCredentials,
   MigrationState,
@@ -33,15 +34,6 @@ vi.mock('./credentials.js', async (importOriginal) => ({
     Promise.resolve(makeMockCredentials()),
   ),
 }));
-
-type MockMigration = {
-  credentials: MigrationCredentials;
-  confirmationToken?: string | undefined;
-  newPrivateKey?: string | undefined;
-  calls: number;
-  run: Mock<() => Promise<MigrationState>> | undefined;
-  state: MigrationState;
-};
 
 describe('handleMigrateInteractive', () => {
   let mockPrivateKey: string | undefined;
@@ -75,7 +67,7 @@ describe('handleMigrateInteractive', () => {
       .mockResolvedValueOnce('RequestedPlcOperation')
       .mockResolvedValueOnce('Finalized');
 
-    await handleMigrateInteractive();
+    await handleInteractive();
 
     expect(vi.mocked(Migration).mock.instances[0]?.confirmationToken).toBe(
       mockToken,
@@ -97,7 +89,7 @@ describe('handleMigrateInteractive', () => {
   it('should handle a failed migration in the Ready state', async () => {
     runMock.mockRejectedValueOnce(new Error('foo'));
 
-    await expect(handleMigrateInteractive()).rejects.toThrow(new Error('foo'));
+    await expect(handleInteractive()).rejects.toThrow(new Error('foo'));
 
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining('Migration failed during state "Ready"'),
@@ -117,7 +109,7 @@ describe('handleMigrateInteractive', () => {
       return Promise.reject(new Error('foo'));
     });
 
-    await expect(handleMigrateInteractive()).rejects.toThrow(new Error('foo'));
+    await expect(handleInteractive()).rejects.toThrow(new Error('foo'));
 
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining(
@@ -140,7 +132,7 @@ describe('handleMigrateInteractive', () => {
       return Promise.reject(new Error('foo'));
     });
 
-    await expect(handleMigrateInteractive()).rejects.toThrow(new Error('foo'));
+    await expect(handleInteractive()).rejects.toThrow(new Error('foo'));
 
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining(

--- a/src/commands/migrate/interactive.ts
+++ b/src/commands/migrate/interactive.ts
@@ -11,7 +11,10 @@ import {
   logWrapped,
 } from '../../utils/index.js';
 
-export async function handleMigrateInteractive(): Promise<void> {
+/**
+ * Handles the interactive migration mode.
+ */
+export async function handleInteractive(): Promise<void> {
   logIntroduction();
 
   const { credentials, migration } = (await initializeMigration()) ?? {};

--- a/src/commands/migrate/pipe.test.ts
+++ b/src/commands/migrate/pipe.test.ts
@@ -3,15 +3,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { handlePipe } from './pipe.js';
 import { makeMockCredentials } from '../../../test/utils.js';
-import type { MockMigration } from '../../../test/utils.js';
-import { Migration } from '../../migration/index.js';
+import { Migration, operations } from '../../migration/index.js';
 import type { SerializedMigration } from '../../migration/types.js';
 
-vi.mock('../../migration/index.js', () => ({
-  Migration: {
-    deserialize: vi.fn(),
-  },
-}));
+vi.mock('../../migration/operations/index.js', async () => {
+  const { makeMockOperations } = await import('../../../test/utils.js');
+  return makeMockOperations({
+    initializeAgents: vi.fn().mockResolvedValue({
+      oldAgent: {},
+      newAgent: {},
+      accountDid: 'foo',
+    }),
+  });
+});
 
 type Stdin = typeof process.stdin;
 type Stdout = typeof process.stdout;
@@ -19,8 +23,6 @@ type Stdout = typeof process.stdout;
 describe('handlePipe', () => {
   let mockStdin: Readable;
   let mockStdout: Writable;
-  let mockMigration: MockMigration;
-  let mockSerializedMigration: SerializedMigration;
   let writtenOutput: string;
 
   beforeEach(() => {
@@ -38,99 +40,85 @@ describe('handlePipe', () => {
       },
     );
     vi.spyOn(process, 'stdout', 'get').mockReturnValue(mockStdout as Stdout);
-
-    mockMigration = {
-      run: vi.fn(),
-      serialize: vi.fn(),
-      deserialize: vi.fn(),
-      state: 'Ready',
-      confirmationToken: undefined,
-      newPrivateKey: undefined,
-      credentials: makeMockCredentials(),
-    };
-
-    mockSerializedMigration = {
-      state: 'Ready',
-      credentials: makeMockCredentials(),
-    };
-
-    vi.mocked(Migration.deserialize).mockResolvedValue(
-      mockMigration as unknown as Migration,
-    );
   });
 
   it('runs migration until RequestedPlcOperation when no confirmation token provided', async () => {
-    const expectedState = 'RequestedPlcOperation';
-    vi.mocked(mockMigration.run).mockResolvedValue(expectedState);
-
-    const serializedResult: SerializedMigration = {
-      ...mockSerializedMigration,
-      state: expectedState,
-    };
-    vi.mocked(mockMigration.serialize).mockReturnValue(serializedResult);
-
-    mockStdin.push(JSON.stringify(mockSerializedMigration));
-    mockStdin.push(null);
-
-    await handlePipe();
-
-    expect(Migration.deserialize).toHaveBeenCalledOnce();
-    expect(Migration.deserialize).toHaveBeenCalledWith(mockSerializedMigration);
-
-    expect(mockMigration.run).toHaveBeenCalledOnce();
-
-    expect(writtenOutput).toBe(JSON.stringify(serializedResult));
-  });
-
-  it('runs migration to completion when confirmation token provided', async () => {
     const inputData = {
-      ...mockSerializedMigration,
-      confirmationToken: 'test-token',
+      state: 'Ready',
+      credentials: makeMockCredentials(),
     };
-    const expectedState = 'Finalized';
-    const expectedPrivateKey = 'test-private-key';
-
-    mockMigration.confirmationToken = 'test-token';
-    mockMigration.newPrivateKey = expectedPrivateKey;
-    vi.mocked(mockMigration.run).mockResolvedValue(expectedState);
-
-    const serializedResult: SerializedMigration = {
-      ...inputData,
-      state: expectedState,
-      newPrivateKey: expectedPrivateKey,
-    };
-    vi.mocked(mockMigration.serialize).mockReturnValue(serializedResult);
 
     mockStdin.push(JSON.stringify(inputData));
     mockStdin.push(null);
 
     await handlePipe();
 
-    expect(Migration.deserialize).toHaveBeenCalledOnce();
-    expect(Migration.deserialize).toHaveBeenCalledWith(inputData);
+    expect(JSON.parse(writtenOutput)).toStrictEqual({
+      state: 'RequestedPlcOperation',
+      credentials: makeMockCredentials(),
+    });
+  });
 
-    expect(mockMigration.run).toHaveBeenCalledOnce();
+  it('runs migration to completion when confirmation token provided', async () => {
+    const inputData = {
+      state: 'Ready',
+      credentials: makeMockCredentials(),
+      confirmationToken: 'test-token',
+    };
 
-    expect(writtenOutput).toBe(JSON.stringify(serializedResult));
+    mockStdin.push(JSON.stringify(inputData));
+    mockStdin.push(null);
+
+    const expectedState = 'Finalized';
+    const expectedPrivateKey = 'test-private-key';
+
+    vi.mocked(operations.migrateIdentity).mockResolvedValue(expectedPrivateKey);
+
+    await handlePipe();
+
+    expect(JSON.parse(writtenOutput)).toStrictEqual({
+      ...inputData,
+      state: expectedState,
+      newPrivateKey: expectedPrivateKey,
+    });
+  });
+
+  it('handles partial migration', async () => {
+    const inputData = {
+      // No state
+      credentials: makeMockCredentials(),
+    };
+
+    mockStdin.push(JSON.stringify(inputData));
+    mockStdin.push(null);
+
+    await handlePipe();
+
+    expect(JSON.parse(writtenOutput)).toStrictEqual({
+      state: 'RequestedPlcOperation',
+      credentials: makeMockCredentials(),
+    });
   });
 
   it('outputs current state even when migration fails', async () => {
-    vi.mocked(mockMigration.run).mockRejectedValue(
+    const inputData: SerializedMigration = {
+      credentials: makeMockCredentials(),
+      state: 'Ready',
+    };
+
+    mockStdin.push(JSON.stringify(inputData));
+    mockStdin.push(null);
+
+    vi.mocked(operations.createNewAccount).mockRejectedValue(
       new Error('Migration failed'),
     );
 
-    const serializedResult: SerializedMigration = {
-      ...mockSerializedMigration,
-      state: 'Ready',
-    };
-    vi.mocked(mockMigration.serialize).mockReturnValue(serializedResult);
-
-    mockStdin.push(JSON.stringify(mockSerializedMigration));
-    mockStdin.push(null);
-
     await expect(handlePipe()).rejects.toThrow('Migration failed');
 
-    expect(writtenOutput).toBe(JSON.stringify(serializedResult));
+    expect(JSON.parse(writtenOutput)).toStrictEqual({
+      ...inputData,
+      state: 'Initialized',
+    });
   });
 
   it('handles invalid JSON input', async () => {
@@ -150,15 +138,16 @@ describe('handlePipe', () => {
   });
 
   it('handles unexpected migration state', async () => {
-    const unexpectedState = 'Initialized';
-    vi.mocked(mockMigration.run).mockResolvedValue(unexpectedState);
-    vi.mocked(mockMigration.serialize).mockReturnValue({
-      ...mockSerializedMigration,
-      state: unexpectedState,
-    });
+    const inputData: SerializedMigration = {
+      credentials: makeMockCredentials(),
+      state: 'Ready',
+    };
 
-    mockStdin.push(JSON.stringify(mockSerializedMigration));
+    mockStdin.push(JSON.stringify(inputData));
     mockStdin.push(null);
+
+    const unexpectedState = 'Finalized';
+    vi.spyOn(Migration.prototype, 'run').mockResolvedValue(unexpectedState);
 
     await expect(handlePipe()).rejects.toThrow(
       `Fatal: Unexpected migration state "${unexpectedState}" after initial run`,

--- a/src/commands/migrate/pipe.test.ts
+++ b/src/commands/migrate/pipe.test.ts
@@ -1,0 +1,167 @@
+import { Readable, Writable } from 'node:stream';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { handlePipe } from './pipe.js';
+import { makeMockCredentials } from '../../../test/utils.js';
+import type { MockMigration } from '../../../test/utils.js';
+import { Migration } from '../../migration/index.js';
+import type { SerializedMigration } from '../../migration/types.js';
+
+vi.mock('../../migration/index.js', () => ({
+  Migration: {
+    deserialize: vi.fn(),
+  },
+}));
+
+type Stdin = typeof process.stdin;
+type Stdout = typeof process.stdout;
+
+describe('handlePipe', () => {
+  let mockStdin: Readable;
+  let mockStdout: Writable;
+  let mockMigration: MockMigration;
+  let mockSerializedMigration: SerializedMigration;
+  let writtenOutput: string;
+
+  beforeEach(() => {
+    writtenOutput = '';
+
+    mockStdin = new Readable();
+    vi.spyOn(mockStdin, '_read').mockImplementation(() => undefined);
+    vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as Stdin);
+
+    mockStdout = new Writable();
+    vi.spyOn(mockStdout, '_write').mockImplementation(
+      (chunk: Buffer | string, _encoding, callback) => {
+        writtenOutput += chunk.toString();
+        callback();
+      },
+    );
+    vi.spyOn(process, 'stdout', 'get').mockReturnValue(mockStdout as Stdout);
+
+    mockMigration = {
+      run: vi.fn(),
+      serialize: vi.fn(),
+      deserialize: vi.fn(),
+      state: 'Ready',
+      confirmationToken: undefined,
+      newPrivateKey: undefined,
+      credentials: makeMockCredentials(),
+    };
+
+    mockSerializedMigration = {
+      state: 'Ready',
+      credentials: makeMockCredentials(),
+    };
+
+    vi.mocked(Migration.deserialize).mockResolvedValue(
+      mockMigration as unknown as Migration,
+    );
+  });
+
+  it('runs migration until RequestedPlcOperation when no confirmation token provided', async () => {
+    const expectedState = 'RequestedPlcOperation';
+    vi.mocked(mockMigration.run).mockResolvedValue(expectedState);
+
+    const serializedResult: SerializedMigration = {
+      ...mockSerializedMigration,
+      state: expectedState,
+    };
+    vi.mocked(mockMigration.serialize).mockReturnValue(serializedResult);
+
+    mockStdin.push(JSON.stringify(mockSerializedMigration));
+    mockStdin.push(null);
+
+    await handlePipe();
+
+    expect(Migration.deserialize).toHaveBeenCalledOnce();
+    expect(Migration.deserialize).toHaveBeenCalledWith(mockSerializedMigration);
+
+    expect(mockMigration.run).toHaveBeenCalledOnce();
+
+    expect(writtenOutput).toBe(JSON.stringify(serializedResult));
+  });
+
+  it('runs migration to completion when confirmation token provided', async () => {
+    const inputData = {
+      ...mockSerializedMigration,
+      confirmationToken: 'test-token',
+    };
+    const expectedState = 'Finalized';
+    const expectedPrivateKey = 'test-private-key';
+
+    mockMigration.confirmationToken = 'test-token';
+    mockMigration.newPrivateKey = expectedPrivateKey;
+    vi.mocked(mockMigration.run).mockResolvedValue(expectedState);
+
+    const serializedResult: SerializedMigration = {
+      ...inputData,
+      state: expectedState,
+      newPrivateKey: expectedPrivateKey,
+    };
+    vi.mocked(mockMigration.serialize).mockReturnValue(serializedResult);
+
+    mockStdin.push(JSON.stringify(inputData));
+    mockStdin.push(null);
+
+    await handlePipe();
+
+    expect(Migration.deserialize).toHaveBeenCalledOnce();
+    expect(Migration.deserialize).toHaveBeenCalledWith(inputData);
+
+    expect(mockMigration.run).toHaveBeenCalledOnce();
+
+    expect(writtenOutput).toBe(JSON.stringify(serializedResult));
+  });
+
+  it('outputs current state even when migration fails', async () => {
+    vi.mocked(mockMigration.run).mockRejectedValue(
+      new Error('Migration failed'),
+    );
+
+    const serializedResult: SerializedMigration = {
+      ...mockSerializedMigration,
+      state: 'Ready',
+    };
+    vi.mocked(mockMigration.serialize).mockReturnValue(serializedResult);
+
+    mockStdin.push(JSON.stringify(mockSerializedMigration));
+    mockStdin.push(null);
+
+    await expect(handlePipe()).rejects.toThrow('Migration failed');
+
+    expect(writtenOutput).toBe(JSON.stringify(serializedResult));
+  });
+
+  it('handles invalid JSON input', async () => {
+    mockStdin.push('invalid json');
+    mockStdin.push(null);
+
+    await expect(handlePipe()).rejects.toThrow('Invalid input: must be JSON');
+  });
+
+  it('handles non-object JSON input', async () => {
+    mockStdin.push('"string input"');
+    mockStdin.push(null);
+
+    await expect(handlePipe()).rejects.toThrow(
+      'Invalid input: must be a plain JSON object',
+    );
+  });
+
+  it('handles unexpected migration state', async () => {
+    const unexpectedState = 'Initialized';
+    vi.mocked(mockMigration.run).mockResolvedValue(unexpectedState);
+    vi.mocked(mockMigration.serialize).mockReturnValue({
+      ...mockSerializedMigration,
+      state: unexpectedState,
+    });
+
+    mockStdin.push(JSON.stringify(mockSerializedMigration));
+    mockStdin.push(null);
+
+    await expect(handlePipe()).rejects.toThrow(
+      `Fatal: Unexpected migration state "${unexpectedState}" after initial run`,
+    );
+  });
+});

--- a/src/commands/migrate/pipe.ts
+++ b/src/commands/migrate/pipe.ts
@@ -1,4 +1,7 @@
-import { Migration } from '../../migration/index.js';
+import {
+  isPartialSerializedMigration,
+  Migration,
+} from '../../migration/index.js';
 import type { MigrationState } from '../../migration/types.js';
 import { handleUnknownError, isPlainObject } from '../../utils/index.js';
 
@@ -21,7 +24,12 @@ export async function handlePipe(): Promise<void> {
 
   let migration: Migration;
   try {
-    migration = await Migration.deserialize(rawCredentials);
+    migration = isPartialSerializedMigration(rawCredentials)
+      ? await Migration.deserialize({
+          ...rawCredentials,
+          state: 'Ready',
+        })
+      : await Migration.deserialize(rawCredentials);
   } catch (error) {
     throw handleUnknownError('Invalid migration arguments', error);
   }

--- a/src/commands/migrate/pipe.ts
+++ b/src/commands/migrate/pipe.ts
@@ -1,0 +1,59 @@
+import { Migration } from '../../migration/index.js';
+import type { MigrationState } from '../../migration/types.js';
+import { handleUnknownError, isPlainObject } from '../../utils/index.js';
+
+/**
+ * Handles the pipe migration mode.
+ */
+export async function handlePipe(): Promise<void> {
+  const input = await readStdin();
+
+  let rawCredentials: Record<string, unknown>;
+  try {
+    rawCredentials = JSON.parse(input);
+  } catch (error) {
+    throw handleUnknownError('Invalid input: must be JSON', error);
+  }
+
+  if (!isPlainObject(rawCredentials)) {
+    throw new Error('Invalid input: must be a plain JSON object');
+  }
+
+  let migration: Migration;
+  try {
+    migration = await Migration.deserialize(rawCredentials);
+  } catch (error) {
+    throw handleUnknownError('Invalid migration arguments', error);
+  }
+
+  const expectedState: MigrationState =
+    migration.confirmationToken === undefined
+      ? 'RequestedPlcOperation'
+      : 'Finalized';
+
+  try {
+    const state = await migration.run();
+    if (state !== expectedState) {
+      throw new Error(
+        `Fatal: Unexpected migration state "${state}" after initial run`,
+      );
+    }
+    writeStdout(migration.serialize());
+  } catch (error) {
+    writeStdout(migration.serialize());
+    throw error;
+  }
+}
+
+async function readStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function writeStdout(data: Record<string, unknown>): void {
+  // Plain JSON.stringify() for single-line output
+  process.stdout.write(JSON.stringify(data));
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -5,13 +5,10 @@ import * as index from './index.js';
 describe('index', () => {
   it('should have the expected exports', () => {
     expect(Object.keys(index).sort()).toStrictEqual([
-      'isHttpUrl',
-      'isValidHandle',
-      'migration',
-    ]);
-    expect(Object.keys(index.migration).sort()).toStrictEqual([
       'Migration',
       'MigrationState',
+      'isHttpUrl',
+      'isValidHandle',
       'operations',
     ]);
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,9 +6,8 @@ describe('index', () => {
   it('should have the expected exports', () => {
     expect(Object.keys(index).sort()).toStrictEqual([
       'Migration',
-      'MigrationState',
+      'isHandle',
       'isHttpUrl',
-      'isValidHandle',
       'operations',
     ]);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
-export { Migration, MigrationState, operations } from './migration/index.js';
+export type { MigrationState } from './migration/index.js';
+export { Migration, operations } from './migration/index.js';
 export type {
   MigrationCredentials,
   SerializedMigration,
 } from './migration/index.js';
 
-export { isHttpUrl, isValidHandle } from './utils/index.js';
+export { isHttpUrl, isHandle } from './utils/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
-import * as migration from './migration/index.js';
-
-export { migration };
+export { Migration, MigrationState, operations } from './migration/index.js';
+export type {
+  MigrationCredentials,
+  SerializedMigration,
+} from './migration/index.js';
 
 export { isHttpUrl, isValidHandle } from './utils/index.js';

--- a/src/migration/Migration.test.ts
+++ b/src/migration/Migration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { Migration, MigrationState } from './Migration.js';
+import { Migration } from './Migration.js';
 import * as operations from './operations/index.js';
 import type { AgentPair, MigrationCredentials } from './types.js';
 import { makeMockCredentials, mockAccountDid } from '../../test/utils.js';
@@ -16,8 +16,8 @@ vi.mock('./operations/index.js', () => ({
 
 const makeMockAgents = (): AgentPair =>
   ({
-    oldAgent: { logout: vi.fn() },
-    newAgent: { logout: vi.fn() },
+    oldAgent: { login: vi.fn(), logout: vi.fn() },
+    newAgent: { login: vi.fn(), logout: vi.fn() },
     accountDid: mockAccountDid,
   }) as unknown as AgentPair;
 
@@ -48,8 +48,9 @@ describe('Migration', () => {
 
     it('accepts initial state', () => {
       const migration = new Migration(
-        { credentials: mockCredentials, agents: makeMockAgents() },
-        MigrationState.CreatedNewAccount,
+        { credentials: mockCredentials },
+        'CreatedNewAccount',
+        makeMockAgents(),
       );
       expect(migration.accountDid).toBe(mockAccountDid);
     });
@@ -62,7 +63,7 @@ describe('Migration', () => {
         confirmationToken: mockToken,
       });
 
-      expect(await migration.run()).toBe(MigrationState.Finalized);
+      expect(await migration.run()).toBe('Finalized');
 
       // Verify all transitions were called in order
       expect(operations.initializeAgents).toHaveBeenCalledWith({
@@ -91,13 +92,13 @@ describe('Migration', () => {
       const migration = new Migration(
         {
           credentials: mockCredentials,
-          agents,
           confirmationToken: mockToken,
         },
-        MigrationState.Initialized,
+        'Initialized',
+        agents,
       );
 
-      expect(await migration.run()).toBe(MigrationState.Finalized);
+      expect(await migration.run()).toBe('Finalized');
       expect(agents.oldAgent.logout).toHaveBeenCalled();
       expect(agents.newAgent.logout).toHaveBeenCalled();
     });
@@ -105,22 +106,23 @@ describe('Migration', () => {
     it('stops and resumes if confirmation token is missing during RequestedPlcOperation state', async () => {
       const migration = new Migration(
         { credentials: mockCredentials },
-        MigrationState.Ready,
+        'Ready',
       );
 
-      expect(await migration.run()).toBe(MigrationState.RequestedPlcOperation);
+      expect(await migration.run()).toBe('RequestedPlcOperation');
       expect(operations.migrateIdentity).not.toHaveBeenCalled();
 
       migration.confirmationToken = mockToken;
-      expect(await migration.run()).toBe(MigrationState.Finalized);
+      expect(await migration.run()).toBe('Finalized');
     });
   });
 
-  describe('setters', () => {
+  describe('getters and setters', () => {
     it('setting confirmationToken updates token in params', async () => {
       const migration = new Migration(
-        { credentials: mockCredentials, agents: makeMockAgents() },
-        MigrationState.MigratedData,
+        { credentials: mockCredentials },
+        'MigratedData',
+        makeMockAgents(),
       );
 
       migration.confirmationToken = mockToken;
@@ -129,6 +131,148 @@ describe('Migration', () => {
       expect(operations.migrateIdentity).toHaveBeenCalledWith({
         agents: agentsMatcher,
         confirmationToken: mockToken,
+      });
+    });
+  });
+
+  describe('serialize', () => {
+    it('serializes a migration in the Ready state', () => {
+      const migration = new Migration({ credentials: mockCredentials });
+      const serialized = migration.serialize();
+      expect(serialized).toStrictEqual({
+        state: 'Ready',
+        credentials: mockCredentials,
+      });
+    });
+
+    it('serializes a migration in the RequestedPlcOperation state', () => {
+      const migration = new Migration(
+        {
+          credentials: mockCredentials,
+          confirmationToken: mockToken,
+        },
+        'RequestedPlcOperation',
+        makeMockAgents(),
+      );
+      const initialState = migration.serialize();
+
+      expect(initialState).toStrictEqual({
+        state: 'RequestedPlcOperation',
+        credentials: mockCredentials,
+        confirmationToken: mockToken,
+      });
+    });
+
+    it('serializes a migration after running from RequestedPlcOperation state', async () => {
+      const migration = new Migration(
+        {
+          credentials: mockCredentials,
+          confirmationToken: mockToken,
+        },
+        'RequestedPlcOperation',
+        makeMockAgents(),
+      );
+
+      vi.mocked(operations.migrateIdentity).mockResolvedValue(mockPrivateKey);
+      await migration.run();
+      const finalState = migration.serialize();
+
+      // TODO:next the agents end up in here, somehow
+      expect(finalState).toStrictEqual({
+        state: 'Finalized',
+        credentials: mockCredentials,
+        confirmationToken: mockToken,
+        newPrivateKey: mockPrivateKey,
+      });
+    });
+  });
+
+  describe('deserialize', () => {
+    it('deserializes a migration in the Ready state', async () => {
+      const migration = await Migration.deserialize({
+        state: 'Ready',
+        credentials: mockCredentials,
+      });
+
+      expect(migration.state).toBe('Ready');
+    });
+
+    it('deserializes a migration in the RequestedPlcOperation state', async () => {
+      vi.mocked(operations.initializeAgents).mockResolvedValue(
+        makeMockAgents(),
+      );
+
+      const migration = await Migration.deserialize({
+        state: 'RequestedPlcOperation',
+        credentials: mockCredentials,
+        confirmationToken: mockToken,
+      });
+
+      expect(migration.state).toBe('RequestedPlcOperation');
+      expect(migration.confirmationToken).toBe(mockToken);
+    });
+
+    it('deserializes a migration in the Finalized state', async () => {
+      const migration = await Migration.deserialize({
+        state: 'Finalized',
+        credentials: mockCredentials,
+        confirmationToken: mockToken,
+        newPrivateKey: mockPrivateKey,
+      });
+
+      expect(migration.state).toBe('Finalized');
+      expect(migration.confirmationToken).toBe(mockToken);
+      expect(migration.newPrivateKey).toBe(mockPrivateKey);
+    });
+
+    it('deserializing a migration in the ready state does not restore agents', async () => {
+      await Migration.deserialize({
+        state: 'Ready',
+        credentials: mockCredentials,
+      });
+
+      expect(operations.initializeAgents).not.toHaveBeenCalled();
+    });
+
+    it('deserializing a migration in the CreatedNewAccount state restores agents', async () => {
+      const mockAgents = makeMockAgents();
+      vi.mocked(operations.initializeAgents).mockResolvedValue(mockAgents);
+
+      await Migration.deserialize({
+        state: 'CreatedNewAccount',
+        credentials: mockCredentials,
+      });
+
+      expect(operations.initializeAgents).toHaveBeenCalledOnce();
+      expect(operations.initializeAgents).toHaveBeenCalledWith({
+        credentials: mockCredentials,
+      });
+      expect(mockAgents.newAgent.login).toHaveBeenCalledOnce();
+      expect(mockAgents.newAgent.login).toHaveBeenCalledWith({
+        identifier: mockCredentials.newHandle,
+        password: mockCredentials.newPassword,
+      });
+    });
+
+    it('deserializing a migration in the MigratedIdentity state restores agents', async () => {
+      const mockAgents = makeMockAgents();
+      vi.mocked(operations.initializeAgents).mockResolvedValue(mockAgents);
+
+      await Migration.deserialize({
+        state: 'MigratedIdentity',
+        credentials: mockCredentials,
+        confirmationToken: mockToken,
+        newPrivateKey: mockPrivateKey,
+      });
+
+      expect(operations.initializeAgents).toHaveBeenCalledOnce();
+      expect(operations.initializeAgents).toHaveBeenCalledWith({
+        credentials: mockCredentials,
+      });
+      expect(mockAgents.newAgent.login).toHaveBeenCalledOnce();
+      expect(mockAgents.newAgent.login).toHaveBeenCalledWith({
+        identifier: mockCredentials.newHandle,
+        password: mockCredentials.newPassword,
       });
     });
   });

--- a/src/migration/Migration.test.ts
+++ b/src/migration/Migration.test.ts
@@ -177,7 +177,6 @@ describe('Migration', () => {
       await migration.run();
       const finalState = migration.serialize();
 
-      // TODO:next the agents end up in here, somehow
       expect(finalState).toStrictEqual({
         state: 'Finalized',
         credentials: mockCredentials,

--- a/src/migration/Migration.ts
+++ b/src/migration/Migration.ts
@@ -1,5 +1,3 @@
-import { ZodError } from 'zod';
-
 import * as operations from './operations/index.js';
 import { initializeAgents } from './operations/index.js';
 import type {
@@ -13,11 +11,11 @@ import {
   SerializedMigrationSchema,
   stateUtils,
 } from './types.js';
-import { stringify } from '../utils/index.js';
+import { handleUnknownError } from '../utils/index.js';
 
 type BaseData = {
   credentials: MigrationCredentials;
-  confirmationToken?: string;
+  confirmationToken?: string | undefined;
 };
 
 type FinalData = {
@@ -193,12 +191,8 @@ export class Migration {
     try {
       return SerializedMigrationSchema.parse(data);
     } catch (error) {
-      const issues = error instanceof ZodError ? error.issues : undefined;
-      throw new Error(
-        `Invalid migration data: failed to parse.` +
-          (issues ? '\n' + issues.map(stringify).join('\n') : ''),
-        { cause: error },
-      );
+      const message = 'Invalid migration data: failed to parse';
+      throw handleUnknownError(message, error);
     }
   }
 

--- a/src/migration/index.ts
+++ b/src/migration/index.ts
@@ -3,4 +3,4 @@ import * as operations from './operations/index.js';
 export { operations };
 
 export * from './Migration.js';
-export type * from './types.js';
+export * from './types.js';

--- a/src/migration/types.test.ts
+++ b/src/migration/types.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+
+import { isPartialSerializedMigration } from './types.js';
+import { makeMockCredentials } from '../../test/utils.js';
+
+describe('isPartialMigration', () => {
+  it('returns true for valid partial migration without token', () => {
+    const credentials = makeMockCredentials();
+    expect(isPartialSerializedMigration({ credentials })).toBe(true);
+  });
+
+  it('returns true for valid partial migration with token', () => {
+    const credentials = makeMockCredentials();
+    expect(
+      isPartialSerializedMigration({
+        credentials,
+        confirmationToken: '123456',
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['number', 42],
+    ['string', 'string'],
+    ['array', []],
+  ])('returns false for non-object: %s', (_, value) => {
+    expect(isPartialSerializedMigration(value)).toBe(false);
+  });
+
+  it.each([
+    ['empty object', {}],
+    ['object with only token', { confirmationToken: '123456' }],
+  ])('returns false for object without credentials: %s', (_, value) => {
+    expect(isPartialSerializedMigration(value)).toBe(false);
+  });
+
+  it.each([
+    ['state', { state: 'RequestedPlcOperation', credentials: {} }],
+    [
+      'state',
+      { state: 'Finalized', credentials: {}, confirmationToken: '123456' },
+    ],
+    ['state', { state: 'Foo', credentials: {}, confirmationToken: '123456' }],
+  ])('returns false for object with state: %s', (_, value) => {
+    expect(isPartialSerializedMigration(value)).toBe(false);
+  });
+
+  it.each([
+    ['number token', { confirmationToken: 123 }],
+    ['object token', { confirmationToken: {} }],
+  ])('returns false for invalid confirmation token: %s', (_, value) => {
+    const credentials = makeMockCredentials();
+    expect(isPartialSerializedMigration({ credentials, ...value })).toBe(false);
+  });
+
+  it.each([
+    ['empty object', {}],
+    ['object with properties', { foo: 'bar' }],
+  ])('allows credentials as %s', (_, credentials) => {
+    expect(isPartialSerializedMigration({ credentials })).toBe(true);
+  });
+});

--- a/src/migration/types.ts
+++ b/src/migration/types.ts
@@ -58,11 +58,6 @@ export const makeMigrationCredentials = (
   value: unknown,
 ): MigrationCredentials => MigrationCredentialsSchema.parse(value);
 
-export const isMigrationCredentials = (
-  value: unknown,
-): value is MigrationCredentials =>
-  MigrationCredentialsSchema.safeParse(value).success;
-
 const InitialSerializedMigration = object({
   state: MigrationStateSchema.exclude(['MigratedIdentity', 'Finalized']),
   credentials: MigrationCredentialsSchema,

--- a/src/migration/types.ts
+++ b/src/migration/types.ts
@@ -1,15 +1,73 @@
 import type { AtpAgent } from '@atproto/api';
+import type { TypeOf } from 'zod';
+import { object, string, enum as zEnum, union } from 'zod';
 
-export type MigrationCredentials = {
-  oldPdsUrl: string;
-  newPdsUrl: string;
-  oldHandle: string;
-  oldPassword: string;
-  newHandle: string;
-  newEmail: string;
-  newPassword: string;
-  inviteCode: string;
+const migrationStateValues = Object.freeze([
+  'Ready',
+  'Initialized',
+  'CreatedNewAccount',
+  'MigratedData',
+  'RequestedPlcOperation',
+  'MigratedIdentity',
+  'Finalized',
+] as const);
+
+export const MigrationStateSchema = zEnum(migrationStateValues);
+
+export type MigrationState = TypeOf<typeof MigrationStateSchema>;
+
+const stateIndices = Object.freeze(
+  migrationStateValues.reduce<Record<MigrationState, number>>(
+    (acc, state, index) => {
+      acc[state] = index;
+      return acc;
+    },
+    {} as Record<MigrationState, number>,
+  ),
+);
+
+const getStateIndex = (state: MigrationState): number => stateIndices[state];
+
+export const stateUtils = {
+  lt: (state: MigrationState, other: MigrationState): boolean =>
+    getStateIndex(state) < getStateIndex(other),
+
+  gte: (state: MigrationState, other: MigrationState): boolean =>
+    getStateIndex(state) >= getStateIndex(other),
 };
+
+const MigrationCredentials = object({
+  oldPdsUrl: string(),
+  newPdsUrl: string(),
+  oldHandle: string(),
+  oldPassword: string(),
+  newHandle: string(),
+  newEmail: string(),
+  newPassword: string(),
+  inviteCode: string(),
+});
+
+const InitialSerializedMigration = object({
+  state: MigrationStateSchema.exclude(['MigratedIdentity', 'Finalized']),
+  credentials: MigrationCredentials,
+  confirmationToken: string().optional(),
+});
+
+const UltimateSerializedMigration = object({
+  state: MigrationStateSchema.extract(['MigratedIdentity', 'Finalized']),
+  credentials: MigrationCredentials,
+  confirmationToken: string(),
+  newPrivateKey: string(),
+});
+
+export const SerializedMigrationSchema = union([
+  InitialSerializedMigration,
+  UltimateSerializedMigration,
+]);
+
+export type SerializedMigration = TypeOf<typeof SerializedMigrationSchema>;
+
+export type MigrationCredentials = TypeOf<typeof MigrationCredentials>;
 
 export type AgentPair = {
   oldAgent: AtpAgent;

--- a/src/migration/types.ts
+++ b/src/migration/types.ts
@@ -83,6 +83,23 @@ export const SerializedMigrationSchema = union([
 
 export type SerializedMigration = TypeOf<typeof SerializedMigrationSchema>;
 
+const PartialMigrationSchema = object({
+  credentials: object({}).passthrough(),
+  confirmationToken: string().optional(),
+}).strict();
+
+/**
+ * A "partial" migration is a migration with only the credentials and, optionally,
+ * a confirmation token set. We will assume that such a migration is in the
+ * "Ready" state.
+ */
+export type PartialSerializedMigration = TypeOf<typeof PartialMigrationSchema>;
+
+export const isPartialSerializedMigration = (
+  value: unknown,
+): value is PartialSerializedMigration =>
+  PartialMigrationSchema.safeParse(value).success;
+
 export type MigrationCredentials = TypeOf<typeof MigrationCredentialsSchema>;
 
 export type AgentPair = {

--- a/src/utils/handle.test.ts
+++ b/src/utils/handle.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { isValidHandle } from './handle.js';
+import { isHandle } from './handle.js';
 
 describe('isValidHandle', () => {
   it.each([
@@ -39,6 +39,6 @@ describe('isValidHandle', () => {
     [`${'a'.repeat(64)}.bsky.social`, false, 'leftmost segment too long'],
     ['@handle.invalid', false, 'invalid character'],
   ])('%s should return %s (%s)', (handle, expected) => {
-    expect(isValidHandle(handle)).toBe(expected);
+    expect(isHandle(handle)).toBe(expected);
   });
 });

--- a/src/utils/handle.ts
+++ b/src/utils/handle.ts
@@ -19,8 +19,7 @@ const VALIDATE_REGEX =
  * - https://github.com/bluesky-social/social-app/blob/704e36c2801c4c06a3763eaef90c6a3e532a326d/src/lib/strings/handles.ts#L41
  * - https://github.com/bluesky-social/atproto/blob/a940c3fceff7a03e434b12b4dc9ce71ceb3bb419/packages/pds/src/handle/index.ts
  *
- * @param value - The handle to validate.
- * @returns Whether the handle is valid.
+ * @param value - The value to validate.
+ * @returns Whether the value is a valid handle.
  */
-export const isValidHandle = (value: string): boolean =>
-  VALIDATE_REGEX.test(value);
+export const isHandle = (value: string): boolean => VALIDATE_REGEX.test(value);

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -1,7 +1,9 @@
-export const isObject = (
+import { ZodError } from 'zod';
+
+export const isPlainObject = (
   value: unknown,
 ): value is Record<string | number | symbol, unknown> =>
-  typeof value === 'object' && value !== null;
+  typeof value === 'object' && value !== null && !Array.isArray(value);
 
 /**
  * @param value - The value to check.
@@ -19,7 +21,32 @@ export const isHttpUrl = (value: unknown): boolean => {
   }
 };
 
+export const isEmail = (value: unknown): boolean => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(value);
+};
+
 export const stringify = (value: unknown) => JSON.stringify(value, null, 2);
+
+/**
+ * Handle an unknown error. Includes special handling for {@link ZodError} errors.
+ *
+ * @param message - The message to display.
+ * @param error - The error to display.
+ * @returns The readable error.
+ */
+export const handleUnknownError = (message: string, error: unknown): Error => {
+  return error instanceof ZodError
+    ? new Error(
+        message +
+          (error.issues ? '\n' + error.issues.map(stringify).join('\n') : ''),
+        { cause: error },
+      )
+    : new Error(message, { cause: error });
+};
 
 /**
  * Pick non-`#` properties from a type.

--- a/test/echoMigration.js
+++ b/test/echoMigration.js
@@ -1,0 +1,21 @@
+// For getting a serialized migration object that can be piped to the CLI
+
+const serializedMigration = {
+  state: 'Ready',
+  credentials: {
+    oldPdsUrl: 'https://old.bsky.social',
+    newPdsUrl: 'https://new.bsky.social',
+    oldHandle: 'old.handle.com',
+    oldPassword: 'oldpass123',
+    newHandle: 'new.handle.com',
+    newEmail: 'new@email.com',
+    newPassword: 'newpass123',
+    inviteCode: 'invite-123',
+  },
+  confirmationToken: '123456',
+  newPrivateKey: '0xdeadbeef',
+};
+
+console.log(JSON.stringify(serializedMigration));
+
+export {};

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -3,7 +3,7 @@ import type { HeadersMap } from '@atproto/xrpc';
 import type { Mock, Mocked } from 'vitest';
 import { vi } from 'vitest';
 
-import type { Migration } from '../src/migration/index.js';
+import type { Migration, operations } from '../src/migration/index.js';
 import type {
   MigrationCredentials,
   MigrationState,
@@ -29,6 +29,18 @@ export const makeMockCredentials = (): MigrationCredentials => ({
   newEmail: 'new@email.com',
   newPassword: 'newpass123',
   inviteCode: 'invite-123',
+});
+
+export const makeMockOperations = (
+  mocks: Partial<typeof operations> = {},
+): typeof operations => ({
+  initializeAgents: vi.fn(),
+  createNewAccount: vi.fn(),
+  migrateData: vi.fn(),
+  requestPlcOperation: vi.fn(),
+  migrateIdentity: vi.fn(),
+  finalize: vi.fn(),
+  ...mocks,
 });
 
 export const mockAccountDid = 'did:plc:testuser123';

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,9 +1,24 @@
 import type { AtpAgent } from '@atproto/api';
 import type { HeadersMap } from '@atproto/xrpc';
-import type { Mocked } from 'vitest';
+import type { Mock, Mocked } from 'vitest';
 import { vi } from 'vitest';
 
-import type { MigrationCredentials } from '../src/migration/types.js';
+import type { Migration } from '../src/migration/index.js';
+import type {
+  MigrationCredentials,
+  MigrationState,
+  SerializedMigration,
+} from '../src/migration/types.js';
+
+export type MockMigration = {
+  credentials: MigrationCredentials;
+  confirmationToken?: string | undefined;
+  newPrivateKey?: string | undefined;
+  run: Mock<() => Promise<MigrationState>>;
+  state: MigrationState;
+  serialize: Mock<() => SerializedMigration>;
+  deserialize: Mock<() => Migration>;
+};
 
 export const makeMockCredentials = (): MigrationCredentials => ({
   oldPdsUrl: 'https://old.bsky.social',


### PR DESCRIPTION
Closes #17 

Adds a `pipe` mode to the CLI, enabling it to be used as, well, a pipe. A `--file` mode may be added in the future, but such a mode can now also be emulated in userland.

### Changes

- Add `serialize()`/`deserialize()` methods to `Migration`
- Add `pipe` mode to CLI
  - This mode reads from `stdin` and outputs to `stdout`
- Make credential validation more stringent
  - This should catch errors at an earlier stage.
- **BREAKING:** Refactor main module exports

TODO:
- [x] Docs / example usage
- [x] Allow passing in just credentials to start a migration