### PR TITLE
refactor!: Make various CLI improvements

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,9 +6,9 @@ import packageJson from 'bluesky-account-migrator/package.json' assert { type: '
 
 export async function cli(argv: string[], commands: Commands) {
   await yargs(hideBin(argv))
-    .scriptName('bluesky-account-migrator')
+    .scriptName('bam')
     .strict()
-    .usage('Usage: $0 <command> [options]')
+    .usage('Usage: $0 [command] [options]')
     .version(packageJson.version)
     .help()
     .showHelpOnFail(false)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,9 +6,9 @@ import packageJson from 'bluesky-account-migrator/package.json' assert { type: '
 
 export async function cli(argv: string[], commands: Commands) {
   await yargs(hideBin(argv))
-    .scriptName('bam')
+    .scriptName('bluesky-account-migrator')
     .strict()
-    .usage('Usage: $0 [command] [options]')
+    .usage('Usage:\n  $0 [migrate] [options]\n  bam [migrate] [options]')
     .version(packageJson.version)
     .help()
     .showHelpOnFail(false)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,6 @@ import { hideBin } from 'yargs/helpers';
 import type { Commands } from './commands/index.js';
 import packageJson from 'bluesky-account-migrator/package.json' assert { type: 'json' };
 
-// TODO:next add debug option, make error stack traces hidden by default
 export async function cli(argv: string[], commands: Commands) {
   await yargs(hideBin(argv))
     .scriptName('bluesky-account-migrator')
@@ -15,6 +14,11 @@ export async function cli(argv: string[], commands: Commands) {
     .showHelpOnFail(false)
     .alias('help', 'h')
     .alias('version', 'v')
+    .option('debug', {
+      describe: 'Show error stack traces',
+      type: 'boolean',
+      default: false,
+    })
     .command(commands)
     .demandCommand(1)
     .parseAsync();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,11 +4,16 @@ import { hideBin } from 'yargs/helpers';
 import type { Commands } from './commands/index.js';
 import packageJson from 'bluesky-account-migrator/package.json' assert { type: 'json' };
 
+const usageDescription = `
+Usage:
+  $0 [migrate] [options]
+  bam [migrate] [options]`;
+
 export async function cli(argv: string[], commands: Commands) {
   await yargs(hideBin(argv))
     .scriptName('bluesky-account-migrator')
     .strict()
-    .usage('Usage:\n  $0 [migrate] [options]\n  bam [migrate] [options]')
+    .usage(usageDescription)
     .version(packageJson.version)
     .help()
     .showHelpOnFail(false)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,5 @@
-import { defaultCommand, migrateCommand } from './migrate/index.js';
+import { migrateCommand } from './migrate/index.js';
 
-export const commands = [defaultCommand, migrateCommand];
+export const commands = [migrateCommand];
 
 export type Commands = typeof commands;

--- a/src/commands/migrate/index.ts
+++ b/src/commands/migrate/index.ts
@@ -12,10 +12,10 @@ export type MigrateOptions = BaseArgv & {
 
 type CommandModule<Args> = RawCommandModule<Record<string, unknown>, Args>;
 
-const modeGroupLabel = 'Mode (choose one)';
+const modeGroupLabel = 'Mode (choose one):';
 
 export const migrateCommand: CommandModule<MigrateOptions> = {
-  command: '$0 [options]',
+  command: '$0',
   aliases: ['migrate', 'm'],
   describe: 'Perform a migration',
   builder: (yarg: Argv) => {

--- a/src/commands/migrate/index.ts
+++ b/src/commands/migrate/index.ts
@@ -2,10 +2,12 @@ import type { Argv, CommandModule as RawCommandModule } from 'yargs';
 
 import { handleInteractive } from './interactive.js';
 import { handlePipe } from './pipe.js';
+import { makeHandler } from '../../utils/cli.js';
+import type { BaseArgv } from '../../utils/cli.js';
 
 type Mode = 'interactive' | 'i' | 'stdin' | 's';
 
-export type MigrateOptions = {
+export type MigrateOptions = BaseArgv & {
   mode: Mode;
 };
 
@@ -25,7 +27,7 @@ export const migrateCommand: CommandModule<MigrateOptions> = {
       })
       .demandOption('mode') as Argv<MigrateOptions>;
   },
-  handler: async (argv) => {
+  handler: makeHandler(async (argv) => {
     if (argv.mode.startsWith('i')) {
       await handleInteractive();
     } else if (argv.mode.startsWith('p')) {
@@ -36,7 +38,7 @@ export const migrateCommand: CommandModule<MigrateOptions> = {
         `Fatal: Migration mode not yet implemented: ${argv.mode}`,
       );
     }
-  },
+  }),
 };
 
 export const defaultCommand: CommandModule<MigrateOptions> = {

--- a/src/commands/migrate/index.ts
+++ b/src/commands/migrate/index.ts
@@ -5,45 +5,51 @@ import { handlePipe } from './pipe.js';
 import { makeHandler } from '../../utils/cli.js';
 import type { BaseArgv } from '../../utils/cli.js';
 
-type Mode = 'interactive' | 'i' | 'stdin' | 's';
-
 export type MigrateOptions = BaseArgv & {
-  mode: Mode;
+  interactive: boolean;
+  pipe: boolean;
 };
 
 type CommandModule<Args> = RawCommandModule<Record<string, unknown>, Args>;
 
+const modeGroupLabel = 'Mode (choose one)';
+
 export const migrateCommand: CommandModule<MigrateOptions> = {
-  command: 'migrate [mode]',
-  aliases: ['m'],
+  command: '$0 [options]',
+  aliases: ['migrate', 'm'],
   describe: 'Perform a migration',
   builder: (yarg: Argv) => {
     return yarg
-      .option('mode', {
-        describe: 'The migration mode to use',
-        type: 'string',
-        default: 'interactive',
-        choices: ['interactive', 'i', 'pipe', 'p'],
+      .option('interactive', {
+        alias: 'i',
+        defaultDescription: 'true',
+        describe: 'Run in interactive mode',
+        conflicts: 'pipe',
+        group: modeGroupLabel,
+        type: 'boolean',
       })
-      .demandOption('mode') as Argv<MigrateOptions>;
+      .option('pipe', {
+        alias: 'p',
+        describe: 'Run in pipe mode',
+        conflicts: 'interactive',
+        group: modeGroupLabel,
+        type: 'boolean',
+      })
+      .middleware((argv) => {
+        if (!argv.interactive && !argv.pipe) {
+          argv.interactive = true;
+        }
+      })
+      .showHelpOnFail(true) as Argv<MigrateOptions>;
   },
   handler: makeHandler(async (argv) => {
-    if (argv.mode.startsWith('i')) {
+    if (argv.interactive) {
       await handleInteractive();
-    } else if (argv.mode.startsWith('p')) {
+    } else if (argv.pipe) {
       await handlePipe();
     } else {
       // This should never happen
-      throw new Error(
-        `Fatal: Migration mode not yet implemented: ${argv.mode}`,
-      );
+      throw new Error('Fatal: No mode specified');
     }
   }),
-};
-
-export const defaultCommand: CommandModule<MigrateOptions> = {
-  command: '$0 [mode]',
-  describe: migrateCommand.describe,
-  builder: migrateCommand.builder,
-  handler: migrateCommand.handler,
 };

--- a/src/commands/migrate/interactive.ts
+++ b/src/commands/migrate/interactive.ts
@@ -168,7 +168,7 @@ function handleSuccess(privateKey: string): void {
 
 async function handleFailure(migration: Migration): Promise<void> {
   console.log();
-  logError(`Error: Migration failed during state "${migration.state}"`);
+  logError(`Migration failed during state "${migration.state}"`);
   if (migration.state !== 'Ready') {
     console.log();
     logError(

--- a/src/migration/Migration.ts
+++ b/src/migration/Migration.ts
@@ -290,6 +290,7 @@ export class Migration {
   async teardown() {
     this.#state = 'Finalized';
     const agents = this.#agents;
+    // Prevent re-entrancy
     this.#agents = undefined;
     if (agents) {
       await Promise.allSettled([

--- a/src/utils/cli.test.ts
+++ b/src/utils/cli.test.ts
@@ -1,0 +1,119 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  beforeAll,
+  afterAll,
+} from 'vitest';
+
+import type { BaseArgv } from './cli.js';
+import { makeHandler } from './cli.js';
+
+const makeArgv = (debug: boolean): BaseArgv => {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  return { debug, _: [], $0: '' };
+};
+
+describe('makeHandler', () => {
+  let originalProcess: typeof process;
+  let mockConsoleError: ReturnType<typeof vi.spyOn>;
+  let mockProcessExitCode: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(() => {
+    originalProcess = globalThis.process;
+    // @ts-expect-error Yeah, you're not supposed to do this.
+    globalThis.process = {
+      exitCode: undefined,
+    };
+  });
+
+  afterAll(() => {
+    globalThis.process = originalProcess;
+  });
+
+  beforeEach(() => {
+    mockConsoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    mockProcessExitCode = vi.spyOn(process, 'exitCode', 'set');
+  });
+
+  it('passes through successful execution', async () => {
+    const mockFn = vi.fn();
+    const handler = makeHandler(mockFn);
+    const argv = makeArgv(false);
+
+    await handler(argv);
+
+    expect(mockFn).toHaveBeenCalledOnce();
+    expect(mockFn).toHaveBeenCalledWith(argv);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+    expect(mockProcessExitCode).not.toHaveBeenCalled();
+  });
+
+  it('handles errors with debug=false', async () => {
+    const error = new Error('test error');
+    const mockFn = vi.fn().mockRejectedValue(error);
+    const handler = makeHandler(mockFn);
+    const argv = makeArgv(false);
+
+    await handler(argv);
+
+    expect(mockConsoleError).toHaveBeenCalledWith('Error: test error');
+    expect(mockProcessExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it('handles errors with debug=true', async () => {
+    const error = new Error('test error');
+    error.stack = ' test error\n    at test';
+    const mockFn = vi.fn().mockRejectedValue(error);
+    const handler = makeHandler(mockFn);
+    const argv = makeArgv(true);
+
+    await handler(argv);
+
+    expect(mockConsoleError).toHaveBeenCalledWith(error);
+    expect(error.message).toBe('Error: test error');
+    expect(mockProcessExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it('converts non-Error thrown values into errors', async () => {
+    const mockFn = vi.fn().mockRejectedValue('string error');
+    const handler = makeHandler(mockFn);
+    const argv = makeArgv(false);
+
+    await handler(argv);
+
+    expect(mockConsoleError).toHaveBeenCalledWith('Error: string error');
+    expect(mockProcessExitCode).toHaveBeenCalledWith(1);
+  });
+
+  it('handles synchronous handlers', async () => {
+    const mockFn = vi.fn();
+    const handler = makeHandler(mockFn);
+    const argv = makeArgv(false);
+
+    await handler(argv);
+
+    expect(mockFn).toHaveBeenCalledOnce();
+    expect(mockFn).toHaveBeenCalledWith(argv);
+    expect(mockConsoleError).not.toHaveBeenCalled();
+    expect(mockProcessExitCode).not.toHaveBeenCalled();
+  });
+
+  it('handles synchronous errors', async () => {
+    const error = new Error('sync error');
+    const mockFn = vi.fn().mockImplementation(() => {
+      throw error;
+    });
+    const handler = makeHandler(mockFn);
+    const argv = makeArgv(false);
+
+    await handler(argv);
+
+    expect(mockConsoleError).toHaveBeenCalledWith('Error: sync error');
+    expect(mockProcessExitCode).toHaveBeenCalledWith(1);
+  });
+});

--- a/src/utils/cli.ts
+++ b/src/utils/cli.ts
@@ -1,0 +1,36 @@
+import type { ArgumentsCamelCase } from 'yargs';
+
+import { intoError } from './misc.js';
+
+export type BaseArgv = ArgumentsCamelCase & {
+  debug: boolean;
+};
+
+type Handler<Argv extends BaseArgv> = (argv: Argv) => void | Promise<void>;
+
+/**
+ * Wraps a handler function to catch errors and handle them based on the debug flag.
+ *
+ * @param handlerFn - The handler function to wrap.
+ * @returns The wrapped handler function.
+ */
+export function makeHandler<Argv extends BaseArgv>(
+  handlerFn: Handler<Argv>,
+): Handler<Argv> {
+  return async (argv) => {
+    try {
+      await handlerFn(argv);
+    } catch (thrown) {
+      const error = intoError(thrown);
+      prefixErrorMessage(error);
+      console.error(argv.debug ? error : error.message);
+      process.exitCode = 1;
+    }
+  };
+}
+
+function prefixErrorMessage(error: Error): void {
+  if (!error.message.startsWith('Error')) {
+    error.message = 'Error: ' + error.message;
+  }
+}

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -48,6 +48,10 @@ export const handleUnknownError = (message: string, error: unknown): Error => {
     : new Error(message, { cause: error });
 };
 
+export const intoError = (error: unknown): Error => {
+  return error instanceof Error ? error : new Error(String(error));
+};
+
 /**
  * Pick non-`#` properties from a type.
  *


### PR DESCRIPTION
- Add a `debug` flag to the CLI
  - Currently this just controls whether error stack traces are shown
- Document `bam` CLI alias
- Use separate flags for CLI modes
  - The `--mode` flag is replaced with `--interactive` and `--pipe` instead.