### PR TITLE
test(cli): Add provisional e2e tests for `--pipe` mode

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Test
-        run: pnpm test
+        run: pnpm test:unit
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -117,41 +117,42 @@ jobs:
             exit 1
           fi
 
-  # test-e2e:
-  #   name: End-to-end test
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - build
-  #   strategy:
-  #     matrix:
-  #       node-version: [18.x, 20.x, 22.x]
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #     - name: Install pnpm
-  #       uses: pnpm/action-setup@v4
-  #       with:
-  #         run_install: false
-  #     - name: Install Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #         cache: 'pnpm'
-  #     - name: Restore build cache
-  #       uses: actions/cache@v4
-  #       with:
-  #         path: ./dist
-  #         key: build-${{ github.sha }}
-  #         fail-on-cache-miss: true
-  #     - name: Install dependencies
-  #       run: pnpm install --frozen-lockfile
-  #     # TODO: Add e2e tests
-  #     # - name: End-to-end test
-  #     #   run: pnpm test:e2e
-  #     - name: Require clean working directory
-  #       shell: bash
-  #       run: |
-  #         if ! git diff --exit-code; then
-  #           echo "Working tree dirty at end of job"
-  #           exit 1
-  #         fi
+  test-e2e:
+    name: End-to-end test
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Install Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'pnpm'
+      - name: Restore build cache
+        uses: actions/cache@v4
+        with:
+          path: ./dist
+          key: build-${{ github.sha }}
+          fail-on-cache-miss: true
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Make test build modifications
+        run: pnpm build:test:fakes
+      - name: End-to-end test
+        run: pnpm test:e2e
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,6 +82,13 @@ const config = createConfig([
 
     extends: [vitest],
   },
+
+  {
+    files: ['test/**/*'],
+    rules: {
+      'n/no-process-env': 'off',
+    },
+  },
 ]);
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' '!CHANGELOG.md' '!pnpm-lock.yaml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
     "lint:types": "tsc --noEmit",
     "lint:fix": "pnpm lint:eslint --fix && pnpm lint:misc --write && pnpm lint:types && pnpm lint:changelog && pnpm lint:dependencies",
-    "test": "vitest run"
+    "test": "pnpm test:unit && pnpm test:e2e",
+    "test:unit": "vitest run",
+    "test:e2e": "vitest run -c vitest.config.e2e.ts"
   },
   "dependencies": {
     "@atproto/api": "^0.13.19",

--- a/test/FakeMigration.ts
+++ b/test/FakeMigration.ts
@@ -92,7 +92,6 @@ export class Migration implements PickPublic<ActualMigration> {
 }
 
 function getFailureCondition() {
-  // eslint-disable-next-line n/no-process-env
   const condition = process.env.FAILURE_CONDITION ?? undefined;
   if (condition !== undefined) {
     if (MigrationStateSchema.safeParse(condition).success) {

--- a/test/e2e/cli.test.ts
+++ b/test/e2e/cli.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+
+import type { SerializedMigration } from '../../src/migration/types.js';
+import { getPackageJson, runCli } from '../utils/cli.js';
+import { makeMockCredentials } from '../utils.js';
+
+describe('CLI', () => {
+  describe('pipe mode', () => {
+    it('completes migration when given valid input', async () => {
+      const credentials = makeMockCredentials();
+      const input: SerializedMigration = {
+        state: 'Ready',
+        credentials,
+      };
+
+      const { stdout } = await runCli(['--pipe'], {
+        input: JSON.stringify(input),
+      });
+
+      const result = JSON.parse(stdout) as SerializedMigration;
+      expect(result.state).toBe('RequestedPlcOperation');
+      expect(result.credentials).toStrictEqual(credentials);
+    });
+
+    it('completes migration with confirmation token', async () => {
+      const credentials = makeMockCredentials();
+      const input: SerializedMigration = {
+        state: 'Ready',
+        credentials,
+        confirmationToken: '123456',
+      };
+
+      const { stdout } = await runCli(['--pipe'], {
+        input: JSON.stringify(input),
+      });
+
+      const result = JSON.parse(stdout) as Record<string, unknown>;
+      expect(result.state).toBe('Finalized');
+      expect(result.credentials).toStrictEqual(credentials);
+      expect(result.newPrivateKey).toBe('0xdeadbeef');
+    });
+
+    it('handles invalid JSON input', async () => {
+      const { stderr, code } = await runCli(['--pipe'], {
+        input: 'invalid json',
+        expectError: true,
+      });
+
+      expect(code).toBe(1);
+      expect(stderr).toContain('Error: Invalid input: must be JSON');
+    });
+
+    it('handles migration failures', async () => {
+      const credentials = makeMockCredentials();
+      const input: SerializedMigration = {
+        state: 'Ready',
+        credentials,
+      };
+
+      // Set failure condition via env var
+      const { stdout, stderr, code } = await runCli(['--pipe'], {
+        input: JSON.stringify(input),
+        env: { FAILURE_CONDITION: 'MigratedData' },
+        expectError: true,
+      });
+
+      const result = JSON.parse(stdout) as SerializedMigration;
+      expect(result.state).toBe('MigratedData');
+      expect(stderr).toContain(
+        'Error: Migration failed during state "MigratedData"',
+      );
+      expect(code).toBe(1);
+    });
+  });
+
+  describe('help', () => {
+    it('shows help text', async () => {
+      const { stdout } = await runCli(['--help']);
+      expect(stdout).toContain('Usage:');
+      expect(stdout).toContain('Options:');
+      expect(stdout).toContain('Mode (choose one):');
+    });
+  });
+
+  describe('version', () => {
+    it('shows version', async () => {
+      const { stdout } = await runCli(['--version']);
+      const { version } = await getPackageJson();
+      expect(stdout).toContain(version);
+    });
+  });
+});

--- a/test/utils/cli.ts
+++ b/test/utils/cli.ts
@@ -1,0 +1,68 @@
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+type RunCliOptions = {
+  input?: string;
+  env?: Record<string, string>;
+  expectError?: boolean;
+};
+
+export async function runCli(
+  args: string[],
+  options: RunCliOptions = {},
+): Promise<{
+  stdout: string;
+  stderr: string;
+  code: number;
+}> {
+  const { input, env, expectError = false } = options;
+
+  const cliPath = await getCliPath();
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      env: { ...process.env, NODE_ENV: 'test', ...env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data;
+    });
+    child.stderr.on('data', (data) => {
+      stderr += data;
+    });
+
+    if (input) {
+      child.stdin.write(input);
+      child.stdin.end();
+    }
+
+    child.on('close', (code) => {
+      const failed = code !== 0;
+      if ((failed && !expectError) || (!failed && expectError)) {
+        reject(
+          Object.assign(new Error('Command failed'), { stdout, stderr, code }),
+        );
+      } else {
+        resolve({ stdout, stderr, code: code ?? 0 });
+      }
+    });
+  });
+}
+
+async function getCliPath() {
+  const packageJson = await getPackageJson();
+  return join(getRootDir(), packageJson.bin.bam);
+}
+
+export async function getPackageJson() {
+  const rootDir = getRootDir();
+  return JSON.parse(await readFile(join(rootDir, 'package.json'), 'utf8'));
+}
+
+function getRootDir() {
+  return join(import.meta.dirname, '../..');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "target": "ES2022",
     "types": ["node"]
   },
-  "include": ["./src", "./test", "vitest.config.ts"]
+  "include": ["./src", "./test", "vitest.config*.ts"]
 }

--- a/vitest.config.e2e.ts
+++ b/vitest.config.e2e.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     restoreMocks: true,
-    include: ['src/**/*.test.ts'],
+    include: ['test/e2e/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Ref: #34 

Adds provisional e2e tests for `--pipe` mode. The test are run in CI by restoring the cached build and modifying it using `build:test:fakes`, which replaces the contents of `dist/Migration.mjs` with a bundle from `FakeMigration.ts`. This actually mocks out too much functionality, hence "provisional" e2e tests.