### PR TITLE
feat!: Support custom handles on the new PDS

### DIFF
--- a/.depcheckrc.json
+++ b/.depcheckrc.json
@@ -4,6 +4,7 @@
     "@metamask/create-release-branch",
     "@tsconfig/node22",
     "@types/*",
+    "@vitest/coverage-istanbul",
     "bluesky-account-migrator",
     "eslint-config-prettier",
     "eslint-import-resolver-typescript",

--- a/README.md
+++ b/README.md
@@ -47,16 +47,35 @@ of this package is based on the snippet in that guide.
 
 #### Custom handles
 
-You cannot submit custom handles—i.e. ones that do not end with `.bsky.social`—
-as your new handle.
-Bluesky's PDS implementation requires that all handles are a subdomain of the PDS
-hostname.
-For example, if your PDS is hosted at `pds.foo.com`, new accounts must have handles
-of the form `*.pds.foo.com`.
-If you already have a custom handle, you can configure it for your migrated account
-after the migration.
-See e.g. [this discussion](https://github.com/bluesky-social/atproto/discussions/2909)
-for how to do this.
+A "custom" handle is a handle that is not a subdomain of the PDS URL. For example,
+for a account hosted on `bsky.social`, `foo.bsky.social` would be a "normal" handle,
+whereas `foo.bar` would be a custom handle.
+
+Bluesky's PDS implementation currently does not support creating new accounts with
+custom handles. However, the handle can be updated after migration. If you submit
+a custom handle as your new handle, the CLI will perform this update at the end
+of the migration, after activating the new account on the new PDS.
+
+For further deatils, see e.g.
+[this discussion](https://github.com/bluesky-social/atproto/discussions/2909)
+and
+[this issue](https://github.com/bluesky-social/pds/issues/110#issuecomment-2439866348).
+
+If you are using [the `pipe` command](#pipe), you will need to provide the temporary and final
+handles in the passed-in credentials, for example:
+
+```json5
+{
+  "credentials": {
+    // The other credentials as normal
+    // ...
+    "newHandle": {
+      "temporaryHandle": "new-temp.pds.com"
+      "finalHandle": "foo.com",
+    },
+  }
+}
+```
 
 ### CLI
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,11 @@ Given a file `credentials.json` with the following contents:
 ```json
 {
   "credentials": {
-    "oldPdsUrl": "https://old.bsky.social",
-    "newPdsUrl": "https://new.bsky.social",
-    "oldHandle": "old.handle.com",
+    "oldPdsUrl": "https://bsky.social",
+    "newPdsUrl": "https://pds.com",
+    "oldHandle": "old.handle",
     "oldPassword": "oldpass123",
-    "newHandle": "new.handle.com",
+    "newHandle": { "handle": "new.pds.com" },
     "newEmail": "new@email.com",
     "newPassword": "newpass123",
     "inviteCode": "invite-123"
@@ -127,11 +127,11 @@ If the credentials are correct, `result.json` should look like this:
 {
   "state": "RequestedPlcOperation",
   "credentials": {
-    "oldPdsUrl": "https://old.bsky.social",
-    "newPdsUrl": "https://new.bsky.social",
-    "oldHandle": "old.handle.com",
+    "oldPdsUrl": "https://bsky.social",
+    "newPdsUrl": "https://pds.com",
+    "oldHandle": "old.handle",
     "oldPassword": "oldpass123",
-    "newHandle": "new.handle.com",
+    "newHandle": { "handle": "new.pds.com" },
     "newEmail": "new@email.com",
     "newPassword": "newpass123",
     "inviteCode": "invite-123"
@@ -156,11 +156,11 @@ If the confirmation token is correct, `finalResult.json` should look like this:
 {
   "state": "Finalized",
   "credentials": {
-    "oldPdsUrl": "https://old.bsky.social",
-    "newPdsUrl": "https://new.bsky.social",
-    "oldHandle": "old.handle.com",
+    "oldPdsUrl": "https://bsky.social",
+    "newPdsUrl": "https://pds.com",
+    "oldHandle": "old.handle",
     "oldPassword": "oldpass123",
-    "newHandle": "new.handle.com",
+    "newHandle": { "handle": "new.pds.com" },
     "newEmail": "new@email.com",
     "newPassword": "newpass123",
     "inviteCode": "invite-123"
@@ -203,12 +203,12 @@ You can run a migration programmatically as follows:
 import { Migration, MigrationState } from 'bluesky-account-migrator';
 
 const credentials = {
-  oldPdsUrl: 'https://old.bsky.social',
-  oldHandle: 'old.handle.com',
+  oldPdsUrl: 'https://bsky.social',
+  oldHandle: 'old.handle',
   oldPassword: 'oldpass123',
   inviteCode: 'invite-123',
-  newPdsUrl: 'https://new.bsky.social',
-  newHandle: 'new.handle.com',
+  newPdsUrl: 'https://pds.com',
+  newHandle: { handle: 'new.pds.com' },
   newEmail: 'new@email.com',
   newPassword: 'newpass123',
 };

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@tsconfig/node22": "^22.0.0",
     "@types/node": "^22.10.1",
     "@types/yargs": "^17.0.33",
+    "@vitest/coverage-istanbul": "^2.1.8",
     "depcheck": "^1.4.7",
     "esbuild": "^0.24.0",
     "eslint": "^9.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       '@types/yargs':
         specifier: ^17.0.33
         version: 17.0.33
+      '@vitest/coverage-istanbul':
+        specifier: ^2.1.8
+        version: 2.1.8(vitest@2.1.8(@types/node@22.10.2))
       depcheck:
         specifier: ^1.4.7
         version: 1.4.7
@@ -117,6 +120,10 @@ importers:
 
 packages:
 
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
   '@atproto/api@0.13.21':
     resolution: {integrity: sha512-iOxSj2YS3Fx9IPz1NivKrSsdYPNbBgpnUH7+WhKYAMvDFDUe2PZe7taau8wsUjJAu/H3S0Mk2TDh5e/7tCRwHA==}
 
@@ -139,9 +146,31 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.26.5':
+    resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.26.0':
+    resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.26.3':
     resolution: {integrity: sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.26.5':
+    resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.25.9':
+    resolution: {integrity: sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.26.0':
+    resolution: {integrity: sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
 
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
@@ -149,6 +178,14 @@ packages:
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.25.9':
+    resolution: {integrity: sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.26.0':
+    resolution: {integrity: sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.26.3':
@@ -610,6 +647,14 @@ packages:
     peerDependencies:
       '@types/node': '>=18'
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -737,6 +782,10 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@pkgr/core@0.1.1':
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
@@ -970,6 +1019,11 @@ packages:
     resolution: {integrity: sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-istanbul@2.1.8':
+    resolution: {integrity: sha512-cSaCd8KcWWvgDwEJSXm0NEWZ1YTiJzjicKHy+zOEbUm0gjbbkz+qJf1p8q71uBzSlS7vdnZA8wRLeiwVE3fFTA==}
+    peerDependencies:
+      vitest: 2.1.8
+
   '@vitest/eslint-plugin@1.1.16':
     resolution: {integrity: sha512-xecwJYuAp11AFsd2aoSnTWO3Wckgu7rjBz1VOhvsDtZzI4s7z/WerAR4gxnEFy37scdsE8wSlP95/2ry6sLhSg==}
     peerDependencies:
@@ -1109,6 +1163,11 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browserslist@4.24.4:
+    resolution: {integrity: sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1127,6 +1186,9 @@ packages:
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
+
+  caniuse-lite@1.0.30001692:
+    resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
 
   chai@5.1.2:
     resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
@@ -1178,6 +1240,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
@@ -1240,11 +1305,20 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  electron-to-chromium@1.5.80:
+    resolution: {integrity: sha512-LTrKpW0AqIuHwmlVNV+cjFYTnXtM9K37OGhpe0ZI10ScPSxqVSryZHIY3WnCS5NSYbBODRTZyhRMS2h5FAEqAw==}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.17.1:
     resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
@@ -1481,6 +1555,10 @@ packages:
   flatted@3.3.2:
     resolution: {integrity: sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==}
 
+  foreground-child@3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+    engines: {node: '>=14'}
+
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1491,6 +1569,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -1518,6 +1600,10 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -1564,6 +1650,9 @@ packages:
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -1643,6 +1732,29 @@ packages:
   iso-datestring-validator@2.2.2:
     resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-instrument@6.0.3:
+    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1703,8 +1815,21 @@ packages:
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   magic-string@0.30.15:
     resolution: {integrity: sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -1739,6 +1864,10 @@ packages:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1763,6 +1892,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  node-releases@2.0.19:
+    resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -1799,6 +1931,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1833,6 +1968,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -1936,6 +2075,10 @@ packages:
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
@@ -1995,6 +2138,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -2034,6 +2181,10 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2106,6 +2257,12 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  update-browserslist-db@1.1.2:
+    resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -2214,6 +2371,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
@@ -2224,6 +2385,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
@@ -2262,6 +2426,11 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@atproto/api@0.13.21':
     dependencies:
@@ -2308,6 +2477,28 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.26.5': {}
+
+  '@babel/core@7.26.0':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.26.2
+      '@babel/generator': 7.26.3
+      '@babel/helper-compilation-targets': 7.26.5
+      '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
+      '@babel/helpers': 7.26.0
+      '@babel/parser': 7.26.3
+      '@babel/template': 7.25.9
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
+      convert-source-map: 2.0.0
+      debug: 4.4.0
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.26.3':
     dependencies:
       '@babel/parser': 7.26.3
@@ -2316,9 +2507,40 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
+  '@babel/helper-compilation-targets@7.26.5':
+    dependencies:
+      '@babel/compat-data': 7.26.5
+      '@babel/helper-validator-option': 7.25.9
+      browserslist: 4.24.4
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-module-imports@7.25.9':
+    dependencies:
+      '@babel/traverse': 7.26.4
+      '@babel/types': 7.26.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.26.0(@babel/core@7.26.0)':
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/helper-module-imports': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/traverse': 7.26.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-option@7.25.9': {}
+
+  '@babel/helpers@7.26.0':
+    dependencies:
+      '@babel/template': 7.25.9
+      '@babel/types': 7.26.3
 
   '@babel/parser@7.26.3':
     dependencies:
@@ -2677,6 +2899,17 @@ snapshots:
     dependencies:
       '@types/node': 22.10.2
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -2817,6 +3050,9 @@ snapshots:
       fastq: 1.17.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@pkgr/core@0.1.1': {}
 
@@ -3047,6 +3283,22 @@ snapshots:
       '@typescript-eslint/types': 8.18.0
       eslint-visitor-keys: 4.2.0
 
+  '@vitest/coverage-istanbul@2.1.8(vitest@2.1.8(@types/node@22.10.2))':
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      debug: 4.4.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magicast: 0.3.5
+      test-exclude: 7.0.1
+      tinyrainbow: 1.2.0
+      vitest: 2.1.8(@types/node@22.10.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/eslint-plugin@1.1.16(@typescript-eslint/utils@8.18.0(eslint@9.17.0)(typescript@5.7.2))(eslint@9.17.0)(typescript@5.7.2)(vitest@2.1.8(@types/node@22.10.2))':
     dependencies:
       '@typescript-eslint/utils': 8.18.0(eslint@9.17.0)(typescript@5.7.2)
@@ -3202,6 +3454,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browserslist@4.24.4:
+    dependencies:
+      caniuse-lite: 1.0.30001692
+      electron-to-chromium: 1.5.80
+      node-releases: 2.0.19
+      update-browserslist-db: 1.1.2(browserslist@4.24.4)
+
   cac@6.7.14: {}
 
   callsite@1.0.0: {}
@@ -3211,6 +3470,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   camelcase@8.0.0: {}
+
+  caniuse-lite@1.0.30001692: {}
 
   chai@5.1.2:
     dependencies:
@@ -3258,6 +3519,8 @@ snapshots:
   comment-parser@1.4.1: {}
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cosmiconfig@7.1.0:
     dependencies:
@@ -3329,9 +3592,15 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  eastasianwidth@0.2.0: {}
+
+  electron-to-chromium@1.5.80: {}
+
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.17.1:
     dependencies:
@@ -3681,12 +3950,19 @@ snapshots:
 
   flatted@3.3.2: {}
 
+  foreground-child@3.3.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
@@ -3707,6 +3983,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -3759,6 +4044,8 @@ snapshots:
   homedir-polyfill@1.0.3:
     dependencies:
       parse-passwd: 1.0.0
+
+  html-escaper@2.0.2: {}
 
   human-signals@2.1.0: {}
 
@@ -3816,6 +4103,43 @@ snapshots:
 
   iso-datestring-validator@2.2.2: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-instrument@6.0.3:
+    dependencies:
+      '@babel/core': 7.26.0
+      '@babel/parser': 7.26.3
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.4.0
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -3862,9 +4186,25 @@ snapshots:
 
   loupe@3.1.2: {}
 
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   magic-string@0.30.15:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@babel/types': 7.26.3
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.6.3
 
   merge-stream@2.0.0: {}
 
@@ -3893,6 +4233,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minipass@7.1.2: {}
+
   ms@2.1.3: {}
 
   multiformats@13.3.1: {}
@@ -3912,6 +4254,8 @@ snapshots:
   nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
+
+  node-releases@2.0.19: {}
 
   npm-run-path@4.0.1:
     dependencies:
@@ -3952,6 +4296,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -3979,6 +4325,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   path-type@4.0.0: {}
 
@@ -4076,6 +4427,8 @@ snapshots:
 
   semver-compare@1.0.0: {}
 
+  semver@6.3.1: {}
+
   semver@7.6.3: {}
 
   shebang-command@2.0.0:
@@ -4119,6 +4472,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.4.0
@@ -4151,6 +4510,12 @@ snapshots:
       tslib: 2.8.1
 
   tapable@2.2.1: {}
+
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   tinybench@2.9.0: {}
 
@@ -4207,6 +4572,12 @@ snapshots:
       multiformats: 13.3.1
 
   undici-types@6.20.0: {}
+
+  update-browserslist-db@1.1.2(browserslist@4.24.4):
+    dependencies:
+      browserslist: 4.24.4
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   uri-js@4.4.1:
     dependencies:
@@ -4313,6 +4684,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
   wrap-ansi@9.0.0:
     dependencies:
       ansi-styles: 6.2.1
@@ -4322,6 +4699,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@3.1.1: {}
 
   yaml@1.10.2: {}
 

--- a/src/commands/migrate/credentials.ts
+++ b/src/commands/migrate/credentials.ts
@@ -3,6 +3,7 @@ import { bold, green } from 'yoctocolors-cjs';
 
 import { confirm, input, password } from './prompts.js';
 import {
+  isPdsSubdomain,
   makeMigrationCredentials,
   type MigrationCredentials,
 } from '../../migration/index.js';
@@ -12,7 +13,14 @@ import {
   isHandle,
   handleUnknownError,
   stringify,
+  isPlainObject,
 } from '../../utils/index.js';
+
+/**
+ * @param handle - The handle to extract the leaf domain from.
+ * @returns The leaf domain of the handle.
+ */
+const extractLeafDomain = (handle: string) => handle.split('.').shift();
 
 export const validateUrl = (value: string) =>
   isHttpUrl(value) || 'Must be a valid HTTP or HTTPS URL string';
@@ -26,28 +34,14 @@ export const validateEmail = (value: string) =>
 export const validateHandle = (value: string) =>
   isHandle(value) || 'Must be a valid handle';
 
-export const stripHandlePrefix = (value: string) => value.replace(/^@/u, '');
-
-/**
- * Validate the new handle, ensuring that it's a subdomain of the new PDS hostname.
- *
- * @param value - The new handle to validate.
- * @param newPdsHostname - The validated new PDS hostname.
- * @returns A string error message or `true` if the handle is valid.
- */
-export const validateNewHandle = (
-  value: string,
+export const validateTemporaryHandle = (
+  newHandle: string,
   newPdsHostname: string,
-): string | true => {
-  if (!isHandle(value)) {
-    return 'Must be a valid handle';
-  }
+) =>
+  (isHandle(newHandle) && isPdsSubdomain(newHandle, newPdsHostname)) ||
+  'Must be a valid handle and a subdomain of the new PDS hostname';
 
-  return (
-    value.endsWith(`.${newPdsHostname}`) ||
-    'Must be a subdomain of the new PDS hostname'
-  );
-};
+export const stripHandlePrefix = (value: string) => value.replace(/^@/u, '');
 
 export async function getCredentialsInteractive(): Promise<
   MigrationCredentials | undefined
@@ -83,8 +77,17 @@ export async function getCredentialsInteractive(): Promise<
 
   const newHandle = await input({
     message: `Enter the desired new handle (e.g. username.${newPdsHostname})`,
-    validate: (value) => validateNewHandle(value, newPdsHostname),
+    validate: (value) => validateHandle(value),
   });
+
+  let newTemporaryHandle: string | undefined;
+  if (!isPdsSubdomain(newHandle, newPdsHostname)) {
+    newTemporaryHandle = await input({
+      message: `Enter the desired temporary new handle (e.g. username.${newPdsHostname})`,
+      validate: (value) => validateTemporaryHandle(value, newPdsHostname),
+      default: `${extractLeafDomain(newHandle)}-temp.${newPdsHostname}`,
+    });
+  }
 
   const newEmail = await input({
     message: 'Enter the desired email address for the new account',
@@ -100,13 +103,18 @@ export async function getCredentialsInteractive(): Promise<
     validate: (value) => value === newPassword || 'Passwords do not match',
   });
 
-  const rawCredentials = {
+  const rawCredentials: MigrationCredentials = {
     oldPdsUrl,
     oldHandle,
     oldPassword,
     inviteCode,
     newPdsUrl,
-    newHandle,
+    newHandle: newTemporaryHandle
+      ? {
+          handle: newTemporaryHandle,
+          finalHandle: newHandle,
+        }
+      : { handle: newHandle },
     newEmail,
     newPassword,
   };
@@ -142,7 +150,6 @@ const credentialLabels = {
   oldPassword: 'Current password',
   inviteCode: 'Invite code',
   newPdsUrl: 'New PDS URL',
-  newHandle: 'New handle',
   newEmail: 'New email',
   newPassword: 'New password',
 } as const;
@@ -154,9 +161,22 @@ function logCredentials(credentials: MigrationCredentials) {
     newPassword: '********',
   };
 
+  const getStringValue = (key: string, value: string) =>
+    `${bold(`${key}:`)}\n${green(value)}`;
+
   const content = Object.entries(redacted)
     .map(([key, value]) => {
-      return `${bold(`${credentialLabels[key as keyof MigrationCredentials]}:`)}\n${green(value)}`;
+      if (isPlainObject(value)) {
+        if ('handle' in value) {
+          return getStringValue('New handle', value.handle);
+        }
+        return `${getStringValue('New handle (temporary)', value.temporaryHandle)}\n${getStringValue('New handle (final)', value.finalHandle)}`;
+      }
+      return getStringValue(
+        // @ts-expect-error
+        credentialLabels[key],
+        value,
+      );
     })
     .join('\n');
 

--- a/src/commands/migrate/credentials.ts
+++ b/src/commands/migrate/credentials.ts
@@ -83,7 +83,10 @@ export async function getCredentialsInteractive(): Promise<
   let newTemporaryHandle: string | undefined;
   if (!isPdsSubdomain(newHandle, newPdsHostname)) {
     newTemporaryHandle = await input({
-      message: `Enter the desired temporary new handle (e.g. username.${newPdsHostname})`,
+      message:
+        'You are using a custom handle. ' +
+        'This requires a temporary handle that will be used during the migration.\n\n' +
+        `Enter the desired temporary new handle (e.g. username.${newPdsHostname})`,
       validate: (value) => validateTemporaryHandle(value, newPdsHostname),
       default: `${extractLeafDomain(newHandle)}-temp.${newPdsHostname}`,
     });

--- a/src/migration/Migration.test.ts
+++ b/src/migration/Migration.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { Migration } from './Migration.js';
 import * as operations from './operations/index.js';
-import type { AgentPair, MigrationCredentials } from './types.js';
+import type { AgentPair } from './types.js';
+import type { MigrationCredentialsWithHandle } from '../../test/utils.js';
 import { makeMockCredentials, mockAccountDid } from '../../test/utils.js';
 
 vi.mock('./operations/index.js', () => ({
@@ -31,7 +32,7 @@ const mockPrivateKey = 'mock-private-key';
 const mockToken = 'mock-token';
 
 describe('Migration', () => {
-  let mockCredentials: MigrationCredentials;
+  let mockCredentials: MigrationCredentialsWithHandle;
 
   beforeEach(() => {
     mockCredentials = makeMockCredentials();
@@ -248,7 +249,7 @@ describe('Migration', () => {
       });
       expect(mockAgents.newAgent.login).toHaveBeenCalledOnce();
       expect(mockAgents.newAgent.login).toHaveBeenCalledWith({
-        identifier: mockCredentials.newHandle,
+        identifier: mockCredentials.newHandle.handle,
         password: mockCredentials.newPassword,
       });
     });
@@ -270,7 +271,7 @@ describe('Migration', () => {
       });
       expect(mockAgents.newAgent.login).toHaveBeenCalledOnce();
       expect(mockAgents.newAgent.login).toHaveBeenCalledWith({
-        identifier: mockCredentials.newHandle,
+        identifier: mockCredentials.newHandle.handle,
         password: mockCredentials.newPassword,
       });
     });

--- a/src/migration/Migration.ts
+++ b/src/migration/Migration.ts
@@ -7,6 +7,7 @@ import type {
   SerializedMigration,
 } from './types.js';
 import {
+  getMigrationHandle,
   MigrationStateSchema,
   SerializedMigrationSchema,
   stateUtils,
@@ -201,7 +202,7 @@ export class Migration {
 
     if (stateUtils.gte(parsed.state, 'CreatedNewAccount')) {
       await agents.newAgent.login({
-        identifier: parsed.credentials.newHandle,
+        identifier: getMigrationHandle(parsed.credentials),
         password: parsed.credentials.newPassword,
       });
     }

--- a/src/migration/operations/account.test.ts
+++ b/src/migration/operations/account.test.ts
@@ -35,7 +35,7 @@ describe('createNewAccount', () => {
 
     expect(newAgent.com.atproto.server.createAccount).toHaveBeenCalledWith(
       {
-        handle: mockCredentials.newHandle,
+        handle: mockCredentials.newHandle.handle,
         email: mockCredentials.newEmail,
         password: mockCredentials.newPassword,
         did: mockAccountDid,
@@ -48,7 +48,7 @@ describe('createNewAccount', () => {
     );
 
     expect(newAgent.login).toHaveBeenCalledWith({
-      identifier: mockCredentials.newHandle,
+      identifier: mockCredentials.newHandle.handle,
       password: mockCredentials.newPassword,
     });
   });

--- a/src/migration/operations/account.ts
+++ b/src/migration/operations/account.ts
@@ -1,4 +1,8 @@
-import type { MigrationCredentials, AgentPair } from '../types.js';
+import {
+  type MigrationCredentials,
+  type AgentPair,
+  getMigrationHandle,
+} from '../types.js';
 
 /**
  * Create a new account on the new PDS and login to it.
@@ -27,7 +31,7 @@ export async function createNewAccount({
 
   await agents.newAgent.com.atproto.server.createAccount(
     {
-      handle: credentials.newHandle,
+      handle: getMigrationHandle(credentials),
       email: credentials.newEmail,
       password: credentials.newPassword,
       did: agents.accountDid,
@@ -40,7 +44,7 @@ export async function createNewAccount({
   );
 
   await agents.newAgent.login({
-    identifier: credentials.newHandle,
+    identifier: getMigrationHandle(credentials),
     password: credentials.newPassword,
   });
 }

--- a/src/migration/operations/finalize.test.ts
+++ b/src/migration/operations/finalize.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 
 import { finalize } from './finalize.js';
+import type { MigrationCredentialsWithFinalHandle } from '../../../test/utils.js';
 import {
+  assertHasFinalHandle,
   makeMockAgent,
   makeMockCredentials,
+  makeMockCredentialsWithFinalHandle,
   mockAccountDid,
 } from '../../../test/utils.js';
 import { makeAuthenticatedAgent } from '../utils.js';
@@ -33,5 +36,52 @@ describe('finalize', () => {
     expect(
       actualOldAgent.com.atproto.server.deactivateAccount,
     ).toHaveBeenCalled();
+    expect(newAgent.com.atproto.identity.updateHandle).not.toHaveBeenCalled();
+  });
+
+  it('should update handle if finalHandle is provided', async () => {
+    const newAgent = makeMockAgent();
+    const mockCredentials: MigrationCredentialsWithFinalHandle =
+      makeMockCredentialsWithFinalHandle('new.bar.com');
+    vi.mocked(makeAuthenticatedAgent).mockResolvedValue(makeMockAgent());
+
+    await finalize({
+      agents: {
+        oldAgent: makeMockAgent(),
+        newAgent,
+        accountDid: mockAccountDid,
+      },
+      credentials: mockCredentials,
+    });
+
+    assertHasFinalHandle(mockCredentials);
+
+    expect(newAgent.com.atproto.identity.updateHandle).toHaveBeenCalled();
+    expect(newAgent.com.atproto.identity.updateHandle).toHaveBeenCalledWith({
+      handle: mockCredentials.newHandle.finalHandle,
+    });
+  });
+
+  it('should throw an error if updating handle fails', async () => {
+    const newAgent = makeMockAgent();
+    vi.mocked(newAgent.com.atproto.identity.updateHandle).mockRejectedValue(
+      new Error('foo'),
+    );
+    const mockCredentials = makeMockCredentialsWithFinalHandle('new.bar.com');
+    vi.mocked(makeAuthenticatedAgent).mockResolvedValue(makeMockAgent());
+
+    const { temporaryHandle, finalHandle } = mockCredentials.newHandle;
+    await expect(
+      finalize({
+        agents: {
+          oldAgent: makeMockAgent(),
+          newAgent,
+          accountDid: mockAccountDid,
+        },
+        credentials: mockCredentials,
+      }),
+    ).rejects.toThrow(
+      `Account successfully migrated, but failed to update handle to "${finalHandle}". The current handle is "${temporaryHandle}".`,
+    );
   });
 });

--- a/src/migration/operations/finalize.ts
+++ b/src/migration/operations/finalize.ts
@@ -27,4 +27,18 @@ export async function finalize({
   });
   // ATTN: The call will fail without the `{}`
   await oldAgent.com.atproto.server.deactivateAccount({});
+
+  if ('finalHandle' in credentials.newHandle) {
+    try {
+      await newAgent.com.atproto.identity.updateHandle({
+        handle: credentials.newHandle.finalHandle,
+      });
+    } catch (error) {
+      const { temporaryHandle, finalHandle } = credentials.newHandle;
+      throw new Error(
+        `Account successfully migrated, but failed to update handle to "${finalHandle}". The current handle is "${temporaryHandle}".`,
+        { cause: error },
+      );
+    }
+  }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -20,16 +20,65 @@ export type MockMigration = {
   deserialize: Mock<() => Migration>;
 };
 
-export const makeMockCredentials = (): MigrationCredentials => ({
-  oldPdsUrl: 'https://old.bsky.social',
-  newPdsUrl: 'https://new.bsky.social',
+export const makeMockCredentials = (): MigrationCredentialsWithHandle => ({
+  oldPdsUrl: 'https://bsky.social',
+  newPdsUrl: 'https://foo.com',
   oldHandle: 'old.handle.com',
   oldPassword: 'oldpass123',
-  newHandle: 'new.handle.com',
+  newHandle: { handle: 'new.foo.com' },
   newEmail: 'new@email.com',
   newPassword: 'newpass123',
   inviteCode: 'invite-123',
 });
+
+export const makeMockCredentialsWithFinalHandle = (
+  finalHandle: string,
+): MigrationCredentialsWithFinalHandle => ({
+  ...makeMockCredentials(),
+  newHandle: {
+    temporaryHandle: 'new.foo.com',
+    finalHandle,
+  },
+});
+
+export type MigrationCredentialsWithHandle = Exclude<
+  MigrationCredentials,
+  'newHandle'
+> & {
+  newHandle: {
+    handle: string;
+  };
+};
+
+export type MigrationCredentialsWithFinalHandle = Exclude<
+  MigrationCredentials,
+  'newHandle'
+> & {
+  newHandle: {
+    temporaryHandle: string;
+    finalHandle: string;
+  };
+};
+
+export const assertHasHandle = (
+  credentials: MigrationCredentials,
+): asserts credentials is MigrationCredentialsWithHandle => {
+  if ('handle' in credentials.newHandle) {
+    return;
+  }
+  throw new Error('handle is not defined');
+};
+
+export const assertHasFinalHandle: (
+  credentials: MigrationCredentials,
+) => asserts credentials is MigrationCredentialsWithFinalHandle = (
+  credentials,
+) => {
+  if ('finalHandle' in credentials.newHandle) {
+    return;
+  }
+  throw new Error('finalHandle is not defined');
+};
 
 export const makeMockOperations = (
   mocks: Partial<typeof operations> = {},
@@ -89,6 +138,7 @@ export function makeMockAgent(did?: string): Mocked<AtpAgent> {
           getRecommendedDidCredentials: vi.fn(),
           signPlcOperation: vi.fn(),
           submitPlcOperation: vi.fn(),
+          updateHandle: vi.fn(),
         },
       },
     },

--- a/test/utils/cli.ts
+++ b/test/utils/cli.ts
@@ -2,6 +2,8 @@ import { spawn } from 'node:child_process';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
+import { stringify } from '../../src/utils/misc.js';
+
 type RunCliOptions = {
   input?: string;
   env?: Record<string, string>;
@@ -44,7 +46,9 @@ export async function runCli(
       const failed = code !== 0;
       if ((failed && !expectError) || (!failed && expectError)) {
         reject(
-          Object.assign(new Error('Command failed'), { stdout, stderr, code }),
+          new Error(
+            `Command failed: ${code}\n${stringify({ stdout, stderr })}`,
+          ),
         );
       } else {
         resolve({ stdout, stderr, code: code ?? 0 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,5 +4,18 @@ export default defineConfig({
   test: {
     restoreMocks: true,
     include: ['src/**/*.test.ts'],
+    coverage: {
+      enabled: true,
+      include: ['src/**/*'],
+      provider: 'istanbul',
+      reporter: ['text', 'json', 'html'],
+      thresholds: {
+        autoUpdate: true,
+        lines: 73.56,
+        functions: 68.13,
+        statements: 73.72,
+        branches: 54.67,
+      },
+    },
   },
 });


### PR DESCRIPTION
Closes #26 

Add support for using a custom handle on the new PDS. This is accomplished by calling the `com.atproto.identity.updateHandle` endpoint as the final step of the migration. Because a temporary non-custom handle has to be used to create the account in the first place, required breaking the format of the migration credentials.