### PR TITLE
fix: Ensure custom handle credentials are set correctly

### DIFF
--- a/src/commands/migrate/credentials.ts
+++ b/src/commands/migrate/credentials.ts
@@ -114,7 +114,7 @@ export async function getCredentialsInteractive(): Promise<
     newPdsUrl,
     newHandle: newTemporaryHandle
       ? {
-          handle: newTemporaryHandle,
+          temporaryHandle: newTemporaryHandle,
           finalHandle: newHandle,
         }
       : { handle: newHandle },

--- a/src/migration/operations/account.ts
+++ b/src/migration/operations/account.ts
@@ -12,29 +12,27 @@ import {
  * @param options.credentials - The credentials.
  */
 export async function createNewAccount({
-  agents,
+  agents: { accountDid, newAgent, oldAgent },
   credentials,
 }: {
   agents: AgentPair;
   credentials: MigrationCredentials;
 }): Promise<void> {
-  const describeRes = await agents.newAgent.com.atproto.server.describeServer();
+  const describeRes = await newAgent.com.atproto.server.describeServer();
   const newServerDid = describeRes.data.did;
 
-  const serviceJwtRes = await agents.oldAgent.com.atproto.server.getServiceAuth(
-    {
-      aud: newServerDid,
-      lxm: 'com.atproto.server.createAccount',
-    },
-  );
+  const serviceJwtRes = await oldAgent.com.atproto.server.getServiceAuth({
+    aud: newServerDid,
+    lxm: 'com.atproto.server.createAccount',
+  });
   const serviceJwt = serviceJwtRes.data.token;
 
-  await agents.newAgent.com.atproto.server.createAccount(
+  await newAgent.com.atproto.server.createAccount(
     {
       handle: getMigrationHandle(credentials),
       email: credentials.newEmail,
       password: credentials.newPassword,
-      did: agents.accountDid,
+      did: accountDid,
       inviteCode: credentials.inviteCode,
     },
     {
@@ -43,7 +41,7 @@ export async function createNewAccount({
     },
   );
 
-  await agents.newAgent.login({
+  await newAgent.login({
     identifier: getMigrationHandle(credentials),
     password: credentials.newPassword,
   });

--- a/src/migration/operations/identity.ts
+++ b/src/migration/operations/identity.ts
@@ -22,15 +22,15 @@ export async function migrateIdentity({
 }): Promise<string> {
   const { recoveryKey, privateKey } = await generateRecoveryKey();
 
-  const getDidCredentials =
+  const didCredentials =
     await newAgent.com.atproto.identity.getRecommendedDidCredentials();
-  const rotationKeys = getDidCredentials.data.rotationKeys ?? [];
-  if (!getDidCredentials.data.rotationKeys) {
+  const rotationKeys = didCredentials.data.rotationKeys ?? [];
+  if (!didCredentials.data.rotationKeys) {
     throw new Error('New PDS did not provide any rotation keys');
   }
 
   const plcCredentials: PlcOperationParams = {
-    ...getDidCredentials.data,
+    ...didCredentials.data,
     rotationKeys: [recoveryKey.did(), ...rotationKeys],
     token: confirmationToken,
   };

--- a/src/migration/types.ts
+++ b/src/migration/types.ts
@@ -124,8 +124,8 @@ export const isPartialSerializedMigration = (
 export type MigrationCredentials = TypeOf<typeof MigrationCredentialsSchema>;
 
 export const getMigrationHandle = (credentials: MigrationCredentials) => {
-  if ('finalHandle' in credentials.newHandle) {
-    return credentials.newHandle.finalHandle;
+  if ('temporaryHandle' in credentials.newHandle) {
+    return credentials.newHandle.temporaryHandle;
   }
   return credentials.newHandle.handle;
 };


### PR DESCRIPTION
The `finalHandle` property was never set on the `newHandle` property of the credentials object during interactive migrations because I never changed its sibling property from `handle` to `temporaryHandle`. Because `handle` is the name of the single property in the non-custom handle case, TypeScript and `zod` just ignore any extraneous properties. "TypeScript isn't type safe" etc. etc.